### PR TITLE
Help command

### DIFF
--- a/console-runner-features/src/test/java/info/javaspec/MockReporter.java
+++ b/console-runner-features/src/test/java/info/javaspec/MockReporter.java
@@ -8,11 +8,11 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
 
-public final class MockRunObserver implements RunObserver {
+public final class MockReporter implements Reporter {
   private final List<Spec> specFailedReceived;
   private final List<Spec> specPassedReceived;
 
-  public MockRunObserver() {
+  public MockReporter() {
     this.specFailedReceived = new LinkedList<>();
     this.specPassedReceived = new LinkedList<>();
   }

--- a/console-runner-features/src/test/java/info/javaspec/MockReporter.java
+++ b/console-runner-features/src/test/java/info/javaspec/MockReporter.java
@@ -1,5 +1,7 @@
 package info.javaspec;
 
+import info.javaspec.console.Reporter;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/console-runner-features/src/test/java/info/javaspec/MockReporter.java
+++ b/console-runner-features/src/test/java/info/javaspec/MockReporter.java
@@ -19,6 +19,13 @@ public final class MockReporter implements Reporter {
     this.specPassedReceived = new LinkedList<>();
   }
 
+  /* HelpObserver */
+
+  @Override
+  public void writeMessage(List<String> lines) { }
+
+  /* RunObserver */
+
   @Override
   public boolean hasFailingSpecs() {
     return !this.specFailedReceived.isEmpty();

--- a/console-runner-features/src/test/java/info/javaspec/MockRunObserver.java
+++ b/console-runner-features/src/test/java/info/javaspec/MockRunObserver.java
@@ -8,11 +8,11 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
 
-public final class MockSpecReporter implements SpecReporter {
+public final class MockRunObserver implements RunObserver {
   private final List<Spec> specFailedReceived;
   private final List<Spec> specPassedReceived;
 
-  public MockSpecReporter() {
+  public MockRunObserver() {
     this.specFailedReceived = new LinkedList<>();
     this.specPassedReceived = new LinkedList<>();
   }

--- a/console-runner-features/src/test/java/info/javaspec/console/MainSteps.java
+++ b/console-runner-features/src/test/java/info/javaspec/console/MainSteps.java
@@ -3,12 +3,12 @@ package info.javaspec.console;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
-import info.javaspec.MockSpecReporter;
+import info.javaspec.MockRunObserver;
 
 /** Steps observing what happens in the overall process of running specs, from *within* the same process */
 public class MainSteps {
   private RunsMain execRunCommand;
-  private MockSpecReporter mockReporter;
+  private MockRunObserver mockReporter;
   private MockExitHandler system;
 
   private Verification declaredSpecsRan;
@@ -22,7 +22,7 @@ public class MainSteps {
 
   @Given("^I have a JavaSpec class runner$")
   public void iHaveAClassRunner() throws Exception {
-    this.mockReporter = new MockSpecReporter();
+    this.mockReporter = new MockRunObserver();
     this.system = new MockExitHandler();
   }
 

--- a/console-runner-features/src/test/java/info/javaspec/console/MainSteps.java
+++ b/console-runner-features/src/test/java/info/javaspec/console/MainSteps.java
@@ -3,12 +3,12 @@ package info.javaspec.console;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
-import info.javaspec.MockRunObserver;
+import info.javaspec.MockReporter;
 
 /** Steps observing what happens in the overall process of running specs, from *within* the same process */
 public class MainSteps {
   private RunsMain execRunCommand;
-  private MockRunObserver mockReporter;
+  private MockReporter mockReporter;
   private MockExitHandler system;
 
   private Verification declaredSpecsRan;
@@ -22,7 +22,7 @@ public class MainSteps {
 
   @Given("^I have a JavaSpec class runner$")
   public void iHaveAClassRunner() throws Exception {
-    this.mockReporter = new MockRunObserver();
+    this.mockReporter = new MockReporter();
     this.system = new MockExitHandler();
   }
 

--- a/console-runner-features/src/test/java/info/javaspec/console/helpers/SpecCollectionHelper.java
+++ b/console-runner-features/src/test/java/info/javaspec/console/helpers/SpecCollectionHelper.java
@@ -1,6 +1,6 @@
 package info.javaspec.console.helpers;
 
-import info.javaspec.MockSpecReporter;
+import info.javaspec.MockRunObserver;
 import info.javaspec.SpecCollection;
 import info.javaspec.lang.lambda.FunctionalDslFactory;
 import info.javaspec.lang.lambda.SpecCollectionFactory;
@@ -38,7 +38,7 @@ public class SpecCollectionHelper {
   }
 
   public void runThatCollection() {
-    getSelectedCollection().runSpecs(new MockSpecReporter());
+    getSelectedCollection().runSpecs(new MockRunObserver());
   }
 
   public SpecCollection getSelectedCollection() {

--- a/console-runner-features/src/test/java/info/javaspec/console/helpers/SpecCollectionHelper.java
+++ b/console-runner-features/src/test/java/info/javaspec/console/helpers/SpecCollectionHelper.java
@@ -1,6 +1,6 @@
 package info.javaspec.console.helpers;
 
-import info.javaspec.MockRunObserver;
+import info.javaspec.MockReporter;
 import info.javaspec.SpecCollection;
 import info.javaspec.lang.lambda.FunctionalDslFactory;
 import info.javaspec.lang.lambda.SpecCollectionFactory;
@@ -38,7 +38,7 @@ public class SpecCollectionHelper {
   }
 
   public void runThatCollection() {
-    getSelectedCollection().runSpecs(new MockRunObserver());
+    getSelectedCollection().runSpecs(new MockReporter());
   }
 
   public SpecCollection getSelectedCollection() {

--- a/console-runner/src/main/java/info/javaspec/Reporter.java
+++ b/console-runner/src/main/java/info/javaspec/Reporter.java
@@ -1,0 +1,3 @@
+package info.javaspec;
+
+public interface Reporter extends RunObserver { }

--- a/console-runner/src/main/java/info/javaspec/Reporter.java
+++ b/console-runner/src/main/java/info/javaspec/Reporter.java
@@ -1,3 +1,0 @@
-package info.javaspec;
-
-public interface Reporter extends RunObserver { }

--- a/console-runner/src/main/java/info/javaspec/RunObserver.java
+++ b/console-runner/src/main/java/info/javaspec/RunObserver.java
@@ -1,6 +1,6 @@
 package info.javaspec;
 
-public interface SpecReporter {
+public interface RunObserver {
   void collectionStarting(SpecCollection collection);
 
   boolean hasFailingSpecs();

--- a/console-runner/src/main/java/info/javaspec/Spec.java
+++ b/console-runner/src/main/java/info/javaspec/Spec.java
@@ -4,5 +4,5 @@ package info.javaspec;
 public interface Spec {
   String intendedBehavior();
 
-  void run(SpecReporter reporter);
+  void run(RunObserver observer);
 }

--- a/console-runner/src/main/java/info/javaspec/SpecCollection.java
+++ b/console-runner/src/main/java/info/javaspec/SpecCollection.java
@@ -8,7 +8,7 @@ public interface SpecCollection {
 
   List<String> intendedBehaviors();
 
-  void runSpecs(SpecReporter reporter);
+  void runSpecs(RunObserver observer);
 
   List<SpecCollection> subCollections();
 }

--- a/console-runner/src/main/java/info/javaspec/console/ArgumentParser.java
+++ b/console-runner/src/main/java/info/javaspec/console/ArgumentParser.java
@@ -1,12 +1,17 @@
 package info.javaspec.console;
 
+import info.javaspec.Reporter;
+import info.javaspec.RunObserver;
+
 import java.util.List;
 
 final class ArgumentParser implements Main.CommandParser {
   private final CommandFactory factory;
+  private final Reporter reporter;
 
-  public ArgumentParser(CommandFactory factory) {
+  public ArgumentParser(CommandFactory factory, Reporter reporter) {
     this.factory = factory;
+    this.reporter = reporter;
   }
 
   @Override
@@ -21,7 +26,7 @@ final class ArgumentParser implements Main.CommandParser {
 
       case "run":
         List<String> classNames = args.subList(1, args.size());
-        return this.factory.runSpecsCommand(classNames);
+        return this.factory.runSpecsCommand(this.reporter, classNames);
 
       default:
         throw InvalidCommand.named(command);
@@ -31,7 +36,7 @@ final class ArgumentParser implements Main.CommandParser {
   interface CommandFactory {
     Command helpCommand();
 
-    Command runSpecsCommand(List<String> classNames);
+    Command runSpecsCommand(RunObserver observer, List<String> classNames);
   }
 
   static final class InvalidCommand extends RuntimeException {

--- a/console-runner/src/main/java/info/javaspec/console/ArgumentParser.java
+++ b/console-runner/src/main/java/info/javaspec/console/ArgumentParser.java
@@ -1,6 +1,5 @@
 package info.javaspec.console;
 
-import info.javaspec.Reporter;
 import info.javaspec.RunObserver;
 
 import java.util.List;

--- a/console-runner/src/main/java/info/javaspec/console/ArgumentParser.java
+++ b/console-runner/src/main/java/info/javaspec/console/ArgumentParser.java
@@ -1,6 +1,7 @@
 package info.javaspec.console;
 
 import info.javaspec.RunObserver;
+import info.javaspec.console.HelpCommand.HelpObserver;
 
 import java.util.List;
 
@@ -16,12 +17,12 @@ final class ArgumentParser implements Main.CommandParser {
   @Override
   public Command parseCommand(List<String> args) {
     if(args.isEmpty())
-      return this.factory.helpCommand();
+      return this.factory.helpCommand(this.reporter);
 
     String command = args.get(0);
     switch(command) {
       case "help":
-        return this.factory.helpCommand();
+        return this.factory.helpCommand(this.reporter);
 
       case "run":
         List<String> classNames = args.subList(1, args.size());
@@ -33,7 +34,7 @@ final class ArgumentParser implements Main.CommandParser {
   }
 
   interface CommandFactory {
-    Command helpCommand();
+    Command helpCommand(HelpObserver observer);
 
     Command runSpecsCommand(RunObserver observer, List<String> classNames);
   }

--- a/console-runner/src/main/java/info/javaspec/console/Command.java
+++ b/console-runner/src/main/java/info/javaspec/console/Command.java
@@ -1,8 +1,6 @@
 package info.javaspec.console;
 
-import info.javaspec.RunObserver;
-
 @FunctionalInterface
 interface Command {
-  int run(RunObserver observer);
+  int run();
 }

--- a/console-runner/src/main/java/info/javaspec/console/Command.java
+++ b/console-runner/src/main/java/info/javaspec/console/Command.java
@@ -1,8 +1,8 @@
 package info.javaspec.console;
 
-import info.javaspec.SpecReporter;
+import info.javaspec.RunObserver;
 
 @FunctionalInterface
 interface Command {
-  int run(SpecReporter reporter);
+  int run(RunObserver observer);
 }

--- a/console-runner/src/main/java/info/javaspec/console/ConsoleReporter.java
+++ b/console-runner/src/main/java/info/javaspec/console/ConsoleReporter.java
@@ -4,6 +4,7 @@ import info.javaspec.Spec;
 import info.javaspec.SpecCollection;
 
 import java.io.PrintStream;
+import java.util.List;
 
 final class ConsoleReporter implements Reporter {
   private final PrintStream output;
@@ -14,6 +15,15 @@ final class ConsoleReporter implements Reporter {
   public ConsoleReporter(PrintStream output) {
     this.output = output;
   }
+
+  /* HelpObserver */
+
+  @Override
+  public void writeMessage(List<String> lines) {
+    throw new UnsupportedOperationException();
+  }
+
+  /* RunObserver */
 
   @Override
   public boolean hasFailingSpecs() {

--- a/console-runner/src/main/java/info/javaspec/console/ConsoleReporter.java
+++ b/console-runner/src/main/java/info/javaspec/console/ConsoleReporter.java
@@ -20,7 +20,7 @@ final class ConsoleReporter implements Reporter {
 
   @Override
   public void writeMessage(List<String> lines) {
-    throw new UnsupportedOperationException();
+    lines.forEach(this.output::println);
   }
 
   /* RunObserver */

--- a/console-runner/src/main/java/info/javaspec/console/ConsoleReporter.java
+++ b/console-runner/src/main/java/info/javaspec/console/ConsoleReporter.java
@@ -1,12 +1,12 @@
 package info.javaspec.console;
 
+import info.javaspec.Reporter;
 import info.javaspec.Spec;
 import info.javaspec.SpecCollection;
-import info.javaspec.RunObserver;
 
 import java.io.PrintStream;
 
-final class ConsoleReporter implements RunObserver {
+final class ConsoleReporter implements Reporter {
   private final PrintStream output;
   private int numStarted;
   private int numFailed;

--- a/console-runner/src/main/java/info/javaspec/console/ConsoleReporter.java
+++ b/console-runner/src/main/java/info/javaspec/console/ConsoleReporter.java
@@ -2,11 +2,11 @@ package info.javaspec.console;
 
 import info.javaspec.Spec;
 import info.javaspec.SpecCollection;
-import info.javaspec.SpecReporter;
+import info.javaspec.RunObserver;
 
 import java.io.PrintStream;
 
-final class ConsoleReporter implements SpecReporter {
+final class ConsoleReporter implements RunObserver {
   private final PrintStream output;
   private int numStarted;
   private int numFailed;

--- a/console-runner/src/main/java/info/javaspec/console/ConsoleReporter.java
+++ b/console-runner/src/main/java/info/javaspec/console/ConsoleReporter.java
@@ -1,6 +1,5 @@
 package info.javaspec.console;
 
-import info.javaspec.Reporter;
 import info.javaspec.Spec;
 import info.javaspec.SpecCollection;
 

--- a/console-runner/src/main/java/info/javaspec/console/HelpCommand.java
+++ b/console-runner/src/main/java/info/javaspec/console/HelpCommand.java
@@ -1,8 +1,32 @@
 package info.javaspec.console;
 
+import java.util.Arrays;
+import java.util.List;
+
 final class HelpCommand implements Command {
+  private final HelpObserver observer;
+
+  public HelpCommand(HelpObserver observer) {
+    this.observer = observer;
+  }
+
   @Override
   public int run() {
+    this.observer.writeMessage(Arrays.asList(
+      "Usage: javaspec <command> [<arguments>]",
+      "",
+      "Commands:",
+      "  help",
+      "    show this help",
+      "",
+      "  run <spec class name> [spec class name...]",
+      "    run specs in Java classes"
+    ));
+
     return 0;
+  }
+
+  public interface HelpObserver {
+    void writeMessage(List<String> lines);
   }
 }

--- a/console-runner/src/main/java/info/javaspec/console/HelpCommand.java
+++ b/console-runner/src/main/java/info/javaspec/console/HelpCommand.java
@@ -1,10 +1,8 @@
 package info.javaspec.console;
 
-import info.javaspec.RunObserver;
-
 final class HelpCommand implements Command {
   @Override
-  public int run(RunObserver observer) {
+  public int run() {
     return 0;
   }
 }

--- a/console-runner/src/main/java/info/javaspec/console/HelpCommand.java
+++ b/console-runner/src/main/java/info/javaspec/console/HelpCommand.java
@@ -1,10 +1,10 @@
 package info.javaspec.console;
 
-import info.javaspec.SpecReporter;
+import info.javaspec.RunObserver;
 
 final class HelpCommand implements Command {
   @Override
-  public int run(SpecReporter reporter) {
+  public int run(RunObserver observer) {
     return 0;
   }
 }

--- a/console-runner/src/main/java/info/javaspec/console/Main.java
+++ b/console-runner/src/main/java/info/javaspec/console/Main.java
@@ -1,7 +1,5 @@
 package info.javaspec.console;
 
-import info.javaspec.Reporter;
-
 import java.util.Arrays;
 import java.util.List;
 

--- a/console-runner/src/main/java/info/javaspec/console/Main.java
+++ b/console-runner/src/main/java/info/javaspec/console/Main.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.List;
 
 public final class Main {
-  private final Reporter reporter;
   private final ExitHandler system;
 
   public static void main(String... args) {
@@ -17,12 +16,11 @@ public final class Main {
 
   static void main(Reporter reporter, ExitHandler system, String... args) {
     CommandParser parser = new ArgumentParser(new StaticCommandFactory(), reporter);
-    Main cli = new Main(reporter, system);
+    Main cli = new Main(system);
     cli.runCommand(parser.parseCommand(Arrays.asList(args)));
   }
 
-  Main(Reporter reporter, ExitHandler system) {
-    this.reporter = reporter;
+  Main(ExitHandler system) {
     this.system = system;
   }
 

--- a/console-runner/src/main/java/info/javaspec/console/Main.java
+++ b/console-runner/src/main/java/info/javaspec/console/Main.java
@@ -1,12 +1,12 @@
 package info.javaspec.console;
 
-import info.javaspec.SpecReporter;
+import info.javaspec.RunObserver;
 
 import java.util.Arrays;
 import java.util.List;
 
 public final class Main {
-  private final SpecReporter reporter;
+  private final RunObserver reporter;
   private final ExitHandler system;
 
   public static void main(String... args) {
@@ -17,13 +17,13 @@ public final class Main {
     );
   }
 
-  static void main(SpecReporter reporter, ExitHandler system, String... args) {
+  static void main(RunObserver reporter, ExitHandler system, String... args) {
     CommandParser parser = new ArgumentParser(new StaticCommandFactory());
     Main cli = new Main(reporter, system);
     cli.runCommand(parser.parseCommand(Arrays.asList(args)));
   }
 
-  Main(SpecReporter reporter, ExitHandler system) {
+  Main(RunObserver reporter, ExitHandler system) {
     this.reporter = reporter;
     this.system = system;
   }

--- a/console-runner/src/main/java/info/javaspec/console/Main.java
+++ b/console-runner/src/main/java/info/javaspec/console/Main.java
@@ -1,12 +1,12 @@
 package info.javaspec.console;
 
-import info.javaspec.RunObserver;
+import info.javaspec.Reporter;
 
 import java.util.Arrays;
 import java.util.List;
 
 public final class Main {
-  private final RunObserver reporter;
+  private final Reporter reporter;
   private final ExitHandler system;
 
   public static void main(String... args) {
@@ -17,13 +17,13 @@ public final class Main {
     );
   }
 
-  static void main(RunObserver reporter, ExitHandler system, String... args) {
+  static void main(Reporter reporter, ExitHandler system, String... args) {
     CommandParser parser = new ArgumentParser(new StaticCommandFactory());
     Main cli = new Main(reporter, system);
     cli.runCommand(parser.parseCommand(Arrays.asList(args)));
   }
 
-  Main(RunObserver reporter, ExitHandler system) {
+  Main(Reporter reporter, ExitHandler system) {
     this.reporter = reporter;
     this.system = system;
   }

--- a/console-runner/src/main/java/info/javaspec/console/Main.java
+++ b/console-runner/src/main/java/info/javaspec/console/Main.java
@@ -18,7 +18,7 @@ public final class Main {
   }
 
   static void main(Reporter reporter, ExitHandler system, String... args) {
-    CommandParser parser = new ArgumentParser(new StaticCommandFactory());
+    CommandParser parser = new ArgumentParser(new StaticCommandFactory(), reporter);
     Main cli = new Main(reporter, system);
     cli.runCommand(parser.parseCommand(Arrays.asList(args)));
   }
@@ -29,7 +29,7 @@ public final class Main {
   }
 
   void runCommand(Command command) {
-    int code = command.run(this.reporter);
+    int code = command.run();
     this.system.exit(code);
   }
 

--- a/console-runner/src/main/java/info/javaspec/console/Reporter.java
+++ b/console-runner/src/main/java/info/javaspec/console/Reporter.java
@@ -1,0 +1,5 @@
+package info.javaspec.console;
+
+import info.javaspec.RunObserver;
+
+public interface Reporter extends RunObserver { }

--- a/console-runner/src/main/java/info/javaspec/console/Reporter.java
+++ b/console-runner/src/main/java/info/javaspec/console/Reporter.java
@@ -3,4 +3,5 @@ package info.javaspec.console;
 import info.javaspec.RunObserver;
 import info.javaspec.console.HelpCommand.HelpObserver;
 
+/** An observer of all things, that handles reporting when running commands */
 public interface Reporter extends HelpObserver, RunObserver { }

--- a/console-runner/src/main/java/info/javaspec/console/Reporter.java
+++ b/console-runner/src/main/java/info/javaspec/console/Reporter.java
@@ -1,5 +1,6 @@
 package info.javaspec.console;
 
 import info.javaspec.RunObserver;
+import info.javaspec.console.HelpCommand.HelpObserver;
 
-public interface Reporter extends RunObserver { }
+public interface Reporter extends HelpObserver, RunObserver { }

--- a/console-runner/src/main/java/info/javaspec/console/RunSpecsCommand.java
+++ b/console-runner/src/main/java/info/javaspec/console/RunSpecsCommand.java
@@ -1,7 +1,7 @@
 package info.javaspec.console;
 
 import info.javaspec.SpecCollection;
-import info.javaspec.SpecReporter;
+import info.javaspec.RunObserver;
 import info.javaspec.lang.lambda.SpecCollectionFactory;
 
 final class RunSpecsCommand implements Command {
@@ -12,7 +12,7 @@ final class RunSpecsCommand implements Command {
   }
 
   @Override
-  public int run(SpecReporter reporter) {
+  public int run(RunObserver observer) {
     SpecCollection rootCollection;
     try {
       rootCollection = this.factory.declareSpecs();
@@ -20,9 +20,9 @@ final class RunSpecsCommand implements Command {
       return 2;
     }
 
-    reporter.runStarting();
-    rootCollection.runSpecs(reporter);
-    reporter.runFinished();
-    return reporter.hasFailingSpecs() ? 1 : 0;
+    observer.runStarting();
+    rootCollection.runSpecs(observer);
+    observer.runFinished();
+    return observer.hasFailingSpecs() ? 1 : 0;
   }
 }

--- a/console-runner/src/main/java/info/javaspec/console/RunSpecsCommand.java
+++ b/console-runner/src/main/java/info/javaspec/console/RunSpecsCommand.java
@@ -14,7 +14,7 @@ final class RunSpecsCommand implements Command {
   }
 
   @Override
-  public int run(RunObserver observer) {
+  public int run() {
     SpecCollection rootCollection;
     try {
       rootCollection = this.factory.declareSpecs();
@@ -22,9 +22,9 @@ final class RunSpecsCommand implements Command {
       return 2;
     }
 
-    observer.runStarting();
-    rootCollection.runSpecs(observer);
-    observer.runFinished();
-    return observer.hasFailingSpecs() ? 1 : 0;
+    this.observer.runStarting();
+    rootCollection.runSpecs(this.observer);
+    this.observer.runFinished();
+    return this.observer.hasFailingSpecs() ? 1 : 0;
   }
 }

--- a/console-runner/src/main/java/info/javaspec/console/RunSpecsCommand.java
+++ b/console-runner/src/main/java/info/javaspec/console/RunSpecsCommand.java
@@ -6,9 +6,11 @@ import info.javaspec.lang.lambda.SpecCollectionFactory;
 
 final class RunSpecsCommand implements Command {
   private final SpecCollectionFactory factory;
+  private final RunObserver observer;
 
-  public RunSpecsCommand(SpecCollectionFactory factory) {
+  public RunSpecsCommand(SpecCollectionFactory factory, RunObserver observer) {
     this.factory = factory;
+    this.observer = observer;
   }
 
   @Override

--- a/console-runner/src/main/java/info/javaspec/console/StaticCommandFactory.java
+++ b/console-runner/src/main/java/info/javaspec/console/StaticCommandFactory.java
@@ -12,6 +12,6 @@ public class StaticCommandFactory implements ArgumentParser.CommandFactory {
 
   @Override
   public Command runSpecsCommand(List<String> classNames) {
-    return new RunSpecsCommand(new FunctionalDslFactory(classNames));
+    return new RunSpecsCommand(new FunctionalDslFactory(classNames), null);
   }
 }

--- a/console-runner/src/main/java/info/javaspec/console/StaticCommandFactory.java
+++ b/console-runner/src/main/java/info/javaspec/console/StaticCommandFactory.java
@@ -1,14 +1,15 @@
 package info.javaspec.console;
 
 import info.javaspec.RunObserver;
+import info.javaspec.console.HelpCommand.HelpObserver;
 import info.javaspec.lang.lambda.FunctionalDslFactory;
 
 import java.util.List;
 
 public class StaticCommandFactory implements ArgumentParser.CommandFactory {
   @Override
-  public Command helpCommand() {
-    return new HelpCommand();
+  public Command helpCommand(HelpObserver observer) {
+    return new HelpCommand(observer);
   }
 
   @Override

--- a/console-runner/src/main/java/info/javaspec/console/StaticCommandFactory.java
+++ b/console-runner/src/main/java/info/javaspec/console/StaticCommandFactory.java
@@ -1,5 +1,6 @@
 package info.javaspec.console;
 
+import info.javaspec.RunObserver;
 import info.javaspec.lang.lambda.FunctionalDslFactory;
 
 import java.util.List;
@@ -11,7 +12,7 @@ public class StaticCommandFactory implements ArgumentParser.CommandFactory {
   }
 
   @Override
-  public Command runSpecsCommand(List<String> classNames) {
-    return new RunSpecsCommand(new FunctionalDslFactory(classNames), null);
+  public Command runSpecsCommand(RunObserver observer, List<String> classNames) {
+    return new RunSpecsCommand(new FunctionalDslFactory(classNames), observer);
   }
 }

--- a/console-runner/src/main/java/info/javaspec/lang/lambda/DescriptiveSpec.java
+++ b/console-runner/src/main/java/info/javaspec/lang/lambda/DescriptiveSpec.java
@@ -1,7 +1,7 @@
 package info.javaspec.lang.lambda;
 
 import info.javaspec.Spec;
-import info.javaspec.SpecReporter;
+import info.javaspec.RunObserver;
 
 final class DescriptiveSpec implements Spec {
   private final String intendedBehavior;
@@ -18,15 +18,15 @@ final class DescriptiveSpec implements Spec {
   }
 
   @Override
-  public void run(SpecReporter reporter) {
-    reporter.specStarting(this);
+  public void run(RunObserver observer) {
+    observer.specStarting(this);
     try {
       this.verification.run();
     } catch(AssertionError | Exception e) {
-      reporter.specFailed(this);
+      observer.specFailed(this);
       return;
     }
 
-    reporter.specPassed(this);
+    observer.specPassed(this);
   }
 }

--- a/console-runner/src/main/java/info/javaspec/lang/lambda/RootCollection.java
+++ b/console-runner/src/main/java/info/javaspec/lang/lambda/RootCollection.java
@@ -2,7 +2,7 @@ package info.javaspec.lang.lambda;
 
 import info.javaspec.Spec;
 import info.javaspec.SpecCollection;
-import info.javaspec.SpecReporter;
+import info.javaspec.RunObserver;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -46,9 +46,9 @@ final class RootCollection implements WritableSpecCollection {
   }
 
   @Override
-  public void runSpecs(SpecReporter reporter) {
-    reporter.collectionStarting(this);
-    this.specs.forEach(x -> x.run(reporter));
-    this.subCollections().forEach(x -> x.runSpecs(reporter));
+  public void runSpecs(RunObserver observer) {
+    observer.collectionStarting(this);
+    this.specs.forEach(x -> x.run(observer));
+    this.subCollections().forEach(x -> x.runSpecs(observer));
   }
 }

--- a/console-runner/src/main/java/info/javaspec/lang/lambda/SequentialCollection.java
+++ b/console-runner/src/main/java/info/javaspec/lang/lambda/SequentialCollection.java
@@ -2,7 +2,7 @@ package info.javaspec.lang.lambda;
 
 import info.javaspec.Spec;
 import info.javaspec.SpecCollection;
-import info.javaspec.SpecReporter;
+import info.javaspec.RunObserver;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -45,10 +45,10 @@ final class SequentialCollection implements WritableSpecCollection {
   }
 
   @Override
-  public void runSpecs(SpecReporter reporter) {
-    reporter.collectionStarting(this);
-    this.specs.forEach(x -> x.run(reporter));
-    this.children.forEach(x -> x.runSpecs(reporter));
+  public void runSpecs(RunObserver observer) {
+    observer.collectionStarting(this);
+    this.specs.forEach(x -> x.run(observer));
+    this.children.forEach(x -> x.runSpecs(observer));
   }
 
   @Override

--- a/console-runner/src/test/java/info/javaspec/console/ArgumentParserTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/ArgumentParserTest.java
@@ -33,25 +33,27 @@ public class ArgumentParserTest {
   public class parseCommand {
     public class givenNoArguments {
       @Test
-      public void returnsHelpCommand() throws Exception {
+      public void returnsHelpCommandWithTheReporter() throws Exception {
         Command helpCommand = Mockito.mock(Command.class);
-        Mockito.when(factory.helpCommand())
+        Mockito.when(factory.helpCommand(Mockito.any()))
           .thenReturn(helpCommand);
 
         Command returned = subject.parseCommand(Collections.emptyList());
         assertThat(returned, sameInstance(helpCommand));
+        Mockito.verify(factory).helpCommand(Mockito.same(reporter));
       }
     }
 
     public class givenHelp {
       @Test
-      public void returnsHelpCommand() throws Exception {
+      public void returnsHelpCommandWithTheReporter() throws Exception {
         Command helpCommand = Mockito.mock(Command.class);
-        Mockito.when(factory.helpCommand())
+        Mockito.when(factory.helpCommand(Mockito.any()))
           .thenReturn(helpCommand);
 
         Command returned = subject.parseCommand(Collections.singletonList("help"));
         assertThat(returned, sameInstance(helpCommand));
+        Mockito.verify(factory).helpCommand(Mockito.same(reporter));
       }
     }
 

--- a/console-runner/src/test/java/info/javaspec/console/ArgumentParserTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/ArgumentParserTest.java
@@ -4,7 +4,6 @@ import de.bechte.junit.runners.context.HierarchicalContextRunner;
 import info.javaspec.console.ArgumentParser.CommandFactory;
 import info.javaspec.console.ArgumentParser.InvalidCommand;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;

--- a/console-runner/src/test/java/info/javaspec/console/ArgumentParserTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/ArgumentParserTest.java
@@ -1,7 +1,6 @@
 package info.javaspec.console;
 
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
-import info.javaspec.Reporter;
 import info.javaspec.RunObserver;
 import info.javaspec.console.ArgumentParser.CommandFactory;
 import info.javaspec.console.ArgumentParser.InvalidCommand;

--- a/console-runner/src/test/java/info/javaspec/console/ArgumentParserTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/ArgumentParserTest.java
@@ -1,6 +1,8 @@
 package info.javaspec.console;
 
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
+import info.javaspec.Reporter;
+import info.javaspec.RunObserver;
 import info.javaspec.console.ArgumentParser.CommandFactory;
 import info.javaspec.console.ArgumentParser.InvalidCommand;
 import org.junit.Before;
@@ -20,11 +22,13 @@ import static org.hamcrest.Matchers.sameInstance;
 public class ArgumentParserTest {
   private Main.CommandParser subject;
   private CommandFactory factory;
+  private Reporter reporter;
 
   @Before
   public void setup() throws Exception {
     factory = Mockito.mock(CommandFactory.class);
-    subject = new ArgumentParser(factory);
+    reporter = Mockito.mock(Reporter.class);
+    subject = new ArgumentParser(factory, reporter);
   }
 
   public class parseCommand {
@@ -56,12 +60,17 @@ public class ArgumentParserTest {
       @Test
       public void createsRunSpecsCommandWithNoClassNames() throws Exception {
         Command runCommand = Mockito.mock(Command.class);
-        Mockito.when(factory.runSpecsCommand(Matchers.anyListOf(String.class)))
-          .thenReturn(runCommand);
+        Mockito.when(
+          factory.runSpecsCommand(
+            Matchers.any(RunObserver.class),
+            Matchers.anyListOf(String.class))
+        ).thenReturn(runCommand);
 
         Command returned = subject.parseCommand(Arrays.asList("run"));
         Mockito.verify(factory).runSpecsCommand(
-          Matchers.eq(Collections.emptyList()));
+          Matchers.same(reporter),
+          Matchers.eq(Collections.emptyList())
+        );
         assertThat(returned, sameInstance(runCommand));
       }
     }
@@ -70,12 +79,17 @@ public class ArgumentParserTest {
       @Test
       public void createsRunSpecsCommandWithTheRestOfTheArgsAsClassNames() throws Exception {
         Command runCommand = Mockito.mock(Command.class);
-        Mockito.when(factory.runSpecsCommand(Matchers.anyListOf(String.class)))
-          .thenReturn(runCommand);
+        Mockito.when(
+          factory.runSpecsCommand(
+            Matchers.any(RunObserver.class),
+            Matchers.anyListOf(String.class))
+        ).thenReturn(runCommand);
 
         Command returned = subject.parseCommand(Arrays.asList("run", "one"));
         Mockito.verify(factory).runSpecsCommand(
-          Matchers.eq(Collections.singletonList("one")));
+          Matchers.same(reporter),
+          Matchers.eq(Collections.singletonList("one"))
+        );
         assertThat(returned, sameInstance(runCommand));
       }
     }

--- a/console-runner/src/test/java/info/javaspec/console/ConsoleReporterTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/ConsoleReporterTest.java
@@ -1,0 +1,38 @@
+package info.javaspec.console;
+
+import de.bechte.junit.runners.context.HierarchicalContextRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Collections;
+
+@RunWith(HierarchicalContextRunner.class)
+public class ConsoleReporterTest {
+  private Reporter subject;
+  private PrintStream output;
+
+  public class writeMessage {
+    @Test
+    public void writesNothingGivenAnEmptyList() throws Exception {
+      output = Mockito.mock(PrintStream.class);
+      subject = new ConsoleReporter(output);
+
+      subject.writeMessage(Collections.emptyList());
+      Mockito.verifyNoMoreInteractions(output);
+    }
+
+    @Test
+    public void writesOneLineForEachGivenString() throws Exception {
+      output = Mockito.mock(PrintStream.class);
+      subject = new ConsoleReporter(output);
+
+      subject.writeMessage(Arrays.asList("one", "two"));
+      Mockito.verify(output).println("one");
+      Mockito.verify(output).println("two");
+      Mockito.verifyNoMoreInteractions(output);
+    }
+  }
+}

--- a/console-runner/src/test/java/info/javaspec/console/HelpCommandTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/HelpCommandTest.java
@@ -1,12 +1,15 @@
 package info.javaspec.console;
 
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
-import info.javaspec.RunObserver;
+import info.javaspec.console.HelpCommand.HelpObserver;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -14,14 +17,13 @@ import static org.hamcrest.Matchers.equalTo;
 @RunWith(HierarchicalContextRunner.class)
 public class HelpCommandTest {
   private Command subject;
+  private MockHelpObserver observer;
 
   public class run {
-    private RunObserver observer;
-
     @Before
     public void setup() throws Exception {
-      subject = new HelpCommand();
-      observer = Mockito.mock(RunObserver.class);
+      observer = new MockHelpObserver();
+      subject = new HelpCommand(observer);
     }
 
     @Test
@@ -30,8 +32,35 @@ public class HelpCommandTest {
       assertThat(status, equalTo(0));
     }
 
-    @Test @Ignore
+    @Test
     public void writesUsageWithTheGivenObserver() throws Exception {
+      subject.run();
+      observer.writeMessageShouldHaveReceived(
+        "Usage: javaspec <command> [<arguments>]",
+        "",
+        "Commands:",
+        "  help",
+        "    show this help",
+        "",
+        "  run <spec class name> [spec class name...]",
+        "    run specs in Java classes"
+      );
+    }
+  }
+
+  private static final class MockHelpObserver implements HelpObserver {
+    private final List<String> writeMessageReceived = new LinkedList<>();
+
+    @Override
+    public void writeMessage(List<String> lines) {
+      this.writeMessageReceived.addAll(lines);
+    }
+
+    public void writeMessageShouldHaveReceived(String... expectedLines) {
+      List<String> expectedList = Arrays.stream(expectedLines)
+        .collect(Collectors.toList());
+
+      assertThat(this.writeMessageReceived, equalTo(expectedList));
     }
   }
 }

--- a/console-runner/src/test/java/info/javaspec/console/HelpCommandTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/HelpCommandTest.java
@@ -1,7 +1,7 @@
 package info.javaspec.console;
 
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
-import info.javaspec.SpecReporter;
+import info.javaspec.RunObserver;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -16,17 +16,17 @@ public class HelpCommandTest {
   private Command subject;
 
   public class run {
-    private SpecReporter reporter;
+    private RunObserver observer;
 
     @Before
     public void setup() throws Exception {
       subject = new HelpCommand();
-      reporter = Mockito.mock(SpecReporter.class);
+      observer = Mockito.mock(RunObserver.class);
     }
 
     @Test
     public void returns0() throws Exception {
-      int status = subject.run(reporter);
+      int status = subject.run(observer);
       assertThat(status, equalTo(0));
     }
 

--- a/console-runner/src/test/java/info/javaspec/console/HelpCommandTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/HelpCommandTest.java
@@ -26,7 +26,7 @@ public class HelpCommandTest {
 
     @Test
     public void returns0() throws Exception {
-      int status = subject.run(observer);
+      int status = subject.run();
       assertThat(status, equalTo(0));
     }
 

--- a/console-runner/src/test/java/info/javaspec/console/MainTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/MainTest.java
@@ -10,15 +10,13 @@ import org.mockito.Mockito;
 public class MainTest {
   public class runCommand {
     private Main subject;
-    private Reporter reporter;
     private Main.ExitHandler system;
     private Command command;
 
     @Before
     public void setup() {
-      this.reporter = Mockito.mock(Reporter.class);
       this.system = Mockito.mock(Main.ExitHandler.class);
-      this.subject = new Main(this.reporter, this.system);
+      this.subject = new Main(this.system);
       this.command = Mockito.mock(Command.class);
     }
 

--- a/console-runner/src/test/java/info/javaspec/console/MainTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/MainTest.java
@@ -1,7 +1,7 @@
 package info.javaspec.console;
 
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
-import info.javaspec.SpecReporter;
+import info.javaspec.RunObserver;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,13 +11,13 @@ import org.mockito.Mockito;
 public class MainTest {
   public class runCommand {
     private Main subject;
-    private SpecReporter reporter;
+    private RunObserver reporter;
     private Main.ExitHandler system;
     private Command command;
 
     @Before
     public void setup() {
-      this.reporter = Mockito.mock(SpecReporter.class);
+      this.reporter = Mockito.mock(RunObserver.class);
       this.system = Mockito.mock(Main.ExitHandler.class);
       this.subject = new Main(this.reporter, this.system);
       this.command = Mockito.mock(Command.class);

--- a/console-runner/src/test/java/info/javaspec/console/MainTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/MainTest.java
@@ -2,7 +2,6 @@ package info.javaspec.console;
 
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
 import info.javaspec.Reporter;
-import info.javaspec.RunObserver;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,12 +26,12 @@ public class MainTest {
     @Test
     public void runsTheCommand() throws Exception {
       subject.runCommand(this.command);
-      Mockito.verify(this.command, Mockito.times(1)).run(this.reporter);
+      Mockito.verify(this.command, Mockito.times(1)).run();
     }
 
     @Test
     public void exitsWithTheExitCodeReturnedByTheCommand() throws Exception {
-      Mockito.stub(this.command.run(this.reporter)).toReturn(42);
+      Mockito.stub(this.command.run()).toReturn(42);
       subject.runCommand(this.command);
       Mockito.verify(this.system, Mockito.times(1)).exit(42);
     }

--- a/console-runner/src/test/java/info/javaspec/console/MainTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/MainTest.java
@@ -1,7 +1,6 @@
 package info.javaspec.console;
 
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
-import info.javaspec.Reporter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/console-runner/src/test/java/info/javaspec/console/MainTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/MainTest.java
@@ -1,6 +1,7 @@
 package info.javaspec.console;
 
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
+import info.javaspec.Reporter;
 import info.javaspec.RunObserver;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,13 +12,13 @@ import org.mockito.Mockito;
 public class MainTest {
   public class runCommand {
     private Main subject;
-    private RunObserver reporter;
+    private Reporter reporter;
     private Main.ExitHandler system;
     private Command command;
 
     @Before
     public void setup() {
-      this.reporter = Mockito.mock(RunObserver.class);
+      this.reporter = Mockito.mock(Reporter.class);
       this.system = Mockito.mock(Main.ExitHandler.class);
       this.subject = new Main(this.reporter, this.system);
       this.command = Mockito.mock(Command.class);

--- a/console-runner/src/test/java/info/javaspec/console/RunSpecsCommandTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/RunSpecsCommandTest.java
@@ -33,21 +33,21 @@ public class RunSpecsCommandTest {
     @Test
     public void declaresSpecs() throws Exception {
       subject = new RunSpecsCommand(factory, observer);
-      subject.run(observer);
+      subject.run();
       Mockito.verify(factory).declareSpecs();
     }
 
     @Test
     public void runsTheReturnedCollection() throws Exception {
       subject = new RunSpecsCommand(factory, observer);
-      subject.run(observer);
+      subject.run();
       Mockito.verify(collection).runSpecs(observer);
     }
 
     @Test
     public void reportsTheRunStartingAndFinishing() throws Exception {
       subject = new RunSpecsCommand(factory, observer);
-      subject.run(observer);
+      subject.run();
       Mockito.verify(observer).runStarting();
       Mockito.verify(observer).runFinished();
     }
@@ -55,7 +55,7 @@ public class RunSpecsCommandTest {
     @Test
     public void returns0WhenThereAreNoFailingSpecs() throws Exception {
       subject = new RunSpecsCommand(factory, observer);
-      int statusCode = subject.run(observer);
+      int statusCode = subject.run();
       assertThat(statusCode, equalTo(0));
     }
 
@@ -64,7 +64,7 @@ public class RunSpecsCommandTest {
       Mockito.when(observer.hasFailingSpecs()).thenReturn(true);
 
       subject = new RunSpecsCommand(factory, observer);
-      int statusCode = subject.run(observer);
+      int statusCode = subject.run();
       assertThat(statusCode, equalTo(1));
     }
 
@@ -74,7 +74,7 @@ public class RunSpecsCommandTest {
         .thenThrow(new RuntimeException("bang!"));
 
       subject = new RunSpecsCommand(factory, observer);
-      int statusCode = subject.run(observer);
+      int statusCode = subject.run();
       assertThat(statusCode, equalTo(2));
     }
   }

--- a/console-runner/src/test/java/info/javaspec/console/RunSpecsCommandTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/RunSpecsCommandTest.java
@@ -32,21 +32,21 @@ public class RunSpecsCommandTest {
 
     @Test
     public void declaresSpecs() throws Exception {
-      subject = new RunSpecsCommand(factory);
+      subject = new RunSpecsCommand(factory, observer);
       subject.run(observer);
       Mockito.verify(factory).declareSpecs();
     }
 
     @Test
     public void runsTheReturnedCollection() throws Exception {
-      subject = new RunSpecsCommand(factory);
+      subject = new RunSpecsCommand(factory, observer);
       subject.run(observer);
       Mockito.verify(collection).runSpecs(observer);
     }
 
     @Test
     public void reportsTheRunStartingAndFinishing() throws Exception {
-      subject = new RunSpecsCommand(factory);
+      subject = new RunSpecsCommand(factory, observer);
       subject.run(observer);
       Mockito.verify(observer).runStarting();
       Mockito.verify(observer).runFinished();
@@ -54,7 +54,7 @@ public class RunSpecsCommandTest {
 
     @Test
     public void returns0WhenThereAreNoFailingSpecs() throws Exception {
-      subject = new RunSpecsCommand(factory);
+      subject = new RunSpecsCommand(factory, observer);
       int statusCode = subject.run(observer);
       assertThat(statusCode, equalTo(0));
     }
@@ -63,7 +63,7 @@ public class RunSpecsCommandTest {
     public void returns1WhenAnySpecsFail() throws Exception {
       Mockito.when(observer.hasFailingSpecs()).thenReturn(true);
 
-      subject = new RunSpecsCommand(factory);
+      subject = new RunSpecsCommand(factory, observer);
       int statusCode = subject.run(observer);
       assertThat(statusCode, equalTo(1));
     }
@@ -73,7 +73,7 @@ public class RunSpecsCommandTest {
       Mockito.when(factory.declareSpecs())
         .thenThrow(new RuntimeException("bang!"));
 
-      subject = new RunSpecsCommand(factory);
+      subject = new RunSpecsCommand(factory, observer);
       int statusCode = subject.run(observer);
       assertThat(statusCode, equalTo(2));
     }

--- a/console-runner/src/test/java/info/javaspec/console/RunSpecsCommandTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/RunSpecsCommandTest.java
@@ -2,15 +2,12 @@ package info.javaspec.console;
 
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
 import info.javaspec.SpecCollection;
-import info.javaspec.SpecReporter;
+import info.javaspec.RunObserver;
 import info.javaspec.lang.lambda.SpecCollectionFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-
-import java.util.Collections;
-import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -19,7 +16,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class RunSpecsCommandTest {
   private RunSpecsCommand subject;
   private SpecCollectionFactory factory;
-  private SpecReporter reporter;
+  private RunObserver observer;
   private SpecCollection collection;
 
   public class run {
@@ -29,45 +26,45 @@ public class RunSpecsCommandTest {
       collection = Mockito.mock(SpecCollection.class);
       Mockito.when(factory.declareSpecs()).thenReturn(collection);
 
-      reporter = Mockito.mock(SpecReporter.class);
-      Mockito.when(reporter.hasFailingSpecs()).thenReturn(false);
+      observer = Mockito.mock(RunObserver.class);
+      Mockito.when(observer.hasFailingSpecs()).thenReturn(false);
     }
 
     @Test
     public void declaresSpecs() throws Exception {
       subject = new RunSpecsCommand(factory);
-      subject.run(reporter);
+      subject.run(observer);
       Mockito.verify(factory).declareSpecs();
     }
 
     @Test
     public void runsTheReturnedCollection() throws Exception {
       subject = new RunSpecsCommand(factory);
-      subject.run(reporter);
-      Mockito.verify(collection).runSpecs(reporter);
+      subject.run(observer);
+      Mockito.verify(collection).runSpecs(observer);
     }
 
     @Test
     public void reportsTheRunStartingAndFinishing() throws Exception {
       subject = new RunSpecsCommand(factory);
-      subject.run(reporter);
-      Mockito.verify(reporter).runStarting();
-      Mockito.verify(reporter).runFinished();
+      subject.run(observer);
+      Mockito.verify(observer).runStarting();
+      Mockito.verify(observer).runFinished();
     }
 
     @Test
     public void returns0WhenThereAreNoFailingSpecs() throws Exception {
       subject = new RunSpecsCommand(factory);
-      int statusCode = subject.run(reporter);
+      int statusCode = subject.run(observer);
       assertThat(statusCode, equalTo(0));
     }
 
     @Test
     public void returns1WhenAnySpecsFail() throws Exception {
-      Mockito.when(reporter.hasFailingSpecs()).thenReturn(true);
+      Mockito.when(observer.hasFailingSpecs()).thenReturn(true);
 
       subject = new RunSpecsCommand(factory);
-      int statusCode = subject.run(reporter);
+      int statusCode = subject.run(observer);
       assertThat(statusCode, equalTo(1));
     }
 
@@ -77,12 +74,8 @@ public class RunSpecsCommandTest {
         .thenThrow(new RuntimeException("bang!"));
 
       subject = new RunSpecsCommand(factory);
-      int statusCode = subject.run(reporter);
+      int statusCode = subject.run(observer);
       assertThat(statusCode, equalTo(2));
     }
-  }
-
-  private List<String> anyClassNames() {
-    return Collections.emptyList();
   }
 }

--- a/console-runner/src/test/java/info/javaspec/console/StaticCommandFactoryTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/StaticCommandFactoryTest.java
@@ -3,6 +3,7 @@ package info.javaspec.console;
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
 import info.javaspec.RunObserver;
 import info.javaspec.console.ArgumentParser.CommandFactory;
+import info.javaspec.console.HelpCommand.HelpObserver;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,7 +26,7 @@ public class StaticCommandFactoryTest {
   public class helpCommand {
     @Test
     public void returnsHelpCommand() throws Exception {
-      Command command = subject.helpCommand();
+      Command command = subject.helpCommand(Mockito.mock(HelpObserver.class));
       assertThat(command, instanceOf(HelpCommand.class));
     }
   }

--- a/console-runner/src/test/java/info/javaspec/console/StaticCommandFactoryTest.java
+++ b/console-runner/src/test/java/info/javaspec/console/StaticCommandFactoryTest.java
@@ -1,10 +1,12 @@
 package info.javaspec.console;
 
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
+import info.javaspec.RunObserver;
 import info.javaspec.console.ArgumentParser.CommandFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 
 import java.util.Collections;
 
@@ -31,7 +33,10 @@ public class StaticCommandFactoryTest {
   public class runSpecsCommand {
     @Test
     public void returnsRunSpecsCommandWithTheGivenClasses() throws Exception {
-      Command command = subject.runSpecsCommand(Collections.emptyList());
+      Command command = subject.runSpecsCommand(
+        Mockito.mock(RunObserver.class),
+        Collections.emptyList()
+      );
       assertThat(command, instanceOf(RunSpecsCommand.class));
     }
   }

--- a/console-runner/src/test/java/info/javaspec/lang/lambda/DescriptiveSpecTest.java
+++ b/console-runner/src/test/java/info/javaspec/lang/lambda/DescriptiveSpecTest.java
@@ -1,7 +1,7 @@
 package info.javaspec.lang.lambda;
 
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
-import info.javaspec.SpecReporter;
+import info.javaspec.RunObserver;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,50 +23,50 @@ public class DescriptiveSpecTest {
   }
 
   public class run {
-    private SpecReporter reporter;
+    private RunObserver observer;
 
     @Before
     public void setup() throws Exception {
-      reporter = Mockito.mock(SpecReporter.class);
+      observer = Mockito.mock(RunObserver.class);
     }
 
     @Test
     public void reportsTheSpecStarting() throws Exception {
       subject = new DescriptiveSpec(anyIntendedBehavior(), anyBehaviorVerification());
-      subject.run(reporter);
-      Mockito.verify(reporter).specStarting(subject);
+      subject.run(observer);
+      Mockito.verify(observer).specStarting(subject);
     }
 
     @Test
     public void runsTheGivenBehaviorVerification() throws Exception {
       BehaviorVerification verification = Mockito.mock(BehaviorVerification.class);
       subject = new DescriptiveSpec(anyIntendedBehavior(), verification);
-      subject.run(reporter);
+      subject.run(observer);
       Mockito.verify(verification).run();
     }
 
     @Test
     public void reportsAPassingSpecWhenTheVerificationDoesNotThrowAnything() throws Exception {
       subject = new DescriptiveSpec(anyIntendedBehavior(), anyBehaviorVerification());
-      subject.run(reporter);
-      Mockito.verify(reporter).specPassed(subject);
-      Mockito.verify(reporter, Mockito.never()).specFailed(subject);
+      subject.run(observer);
+      Mockito.verify(observer).specPassed(subject);
+      Mockito.verify(observer, Mockito.never()).specFailed(subject);
     }
 
     @Test
     public void reportsAFailingSpecWhenTheVerificationThrowsAssertionError() throws Exception {
       subject = new DescriptiveSpec(anyIntendedBehavior(), () -> { throw new AssertionError(); });
-      subject.run(reporter);
-      Mockito.verify(reporter).specFailed(subject);
-      Mockito.verify(reporter, Mockito.never()).specPassed(subject);
+      subject.run(observer);
+      Mockito.verify(observer).specFailed(subject);
+      Mockito.verify(observer, Mockito.never()).specPassed(subject);
     }
 
     @Test
     public void reportsAFailingSpecWhenTheVerificationThrowsExceptions() throws Exception {
       subject = new DescriptiveSpec(anyIntendedBehavior(), () -> { throw new RuntimeException(); });
-      subject.run(reporter);
-      Mockito.verify(reporter).specFailed(subject);
-      Mockito.verify(reporter, Mockito.never()).specPassed(subject);
+      subject.run(observer);
+      Mockito.verify(observer).specFailed(subject);
+      Mockito.verify(observer, Mockito.never()).specPassed(subject);
     }
   }
 

--- a/console-runner/src/test/java/info/javaspec/lang/lambda/RootCollectionTest.java
+++ b/console-runner/src/test/java/info/javaspec/lang/lambda/RootCollectionTest.java
@@ -3,7 +3,7 @@ package info.javaspec.lang.lambda;
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
 import info.javaspec.Spec;
 import info.javaspec.SpecCollection;
-import info.javaspec.SpecReporter;
+import info.javaspec.RunObserver;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -83,18 +83,18 @@ public class RootCollectionTest {
   }
 
   public class runSpecs {
-    private SpecReporter reporter;
+    private RunObserver observer;
 
     @Before
     public void setup() throws Exception {
-      reporter = Mockito.mock(SpecReporter.class);
+      observer = Mockito.mock(RunObserver.class);
     }
 
     @Test
     public void reportsThatTheCollectionIsBeingRun() throws Exception {
       subject = new RootCollection();
-      subject.runSpecs(reporter);
-      Mockito.verify(reporter).collectionStarting(subject);
+      subject.runSpecs(observer);
+      Mockito.verify(observer).collectionStarting(subject);
     }
 
     @Test
@@ -103,9 +103,9 @@ public class RootCollectionTest {
 
       subject = new RootCollection();
       subject.addSpec(spec);
-      subject.runSpecs(reporter);
+      subject.runSpecs(observer);
 
-      Mockito.verify(spec).run(reporter);
+      Mockito.verify(spec).run(observer);
     }
 
     @Test
@@ -116,7 +116,7 @@ public class RootCollectionTest {
       subject = new RootCollection();
       subject.addSpec(addedFirst);
       subject.addSpec(addedSecond);
-      subject.runSpecs(reporter);
+      subject.runSpecs(observer);
 
       InOrder order = Mockito.inOrder(addedFirst, addedSecond);
       order.verify(addedFirst).run(Mockito.any());
@@ -132,11 +132,11 @@ public class RootCollectionTest {
       subject = new RootCollection();
       subject.addSubCollection(firstChild);
       subject.addSubCollection(secondChild);
-      subject.runSpecs(reporter);
+      subject.runSpecs(observer);
 
       InOrder order = Mockito.inOrder(firstChild, secondChild);
-      order.verify(firstChild).runSpecs(reporter);
-      order.verify(secondChild).runSpecs(reporter);
+      order.verify(firstChild).runSpecs(observer);
+      order.verify(secondChild).runSpecs(observer);
       order.verifyNoMoreInteractions();
     }
 
@@ -148,11 +148,11 @@ public class RootCollectionTest {
       subject = new RootCollection();
       subject.addSpec(spec);
       subject.addSubCollection(subCollection);
-      subject.runSpecs(reporter);
+      subject.runSpecs(observer);
 
       InOrder order = Mockito.inOrder(subCollection, spec);
-      order.verify(spec).run(reporter);
-      order.verify(subCollection).runSpecs(reporter);
+      order.verify(spec).run(observer);
+      order.verify(subCollection).runSpecs(observer);
       order.verifyNoMoreInteractions();
     }
 

--- a/console-runner/src/test/java/info/javaspec/lang/lambda/SequentialCollectionTest.java
+++ b/console-runner/src/test/java/info/javaspec/lang/lambda/SequentialCollectionTest.java
@@ -3,7 +3,7 @@ package info.javaspec.lang.lambda;
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
 import info.javaspec.Spec;
 import info.javaspec.SpecCollection;
-import info.javaspec.SpecReporter;
+import info.javaspec.RunObserver;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -84,18 +84,18 @@ public class SequentialCollectionTest {
   }
 
   public class runSpecs {
-    private SpecReporter reporter;
+    private RunObserver observer;
 
     @Before
     public void setup() throws Exception {
-      reporter = Mockito.mock(SpecReporter.class);
+      observer = Mockito.mock(RunObserver.class);
     }
 
     @Test
     public void reportsThatTheCollectionIsBeingRun() throws Exception {
       subject = new SequentialCollection(anyDescription());
-      subject.runSpecs(reporter);
-      Mockito.verify(reporter).collectionStarting(subject);
+      subject.runSpecs(observer);
+      Mockito.verify(observer).collectionStarting(subject);
     }
 
     @Test
@@ -104,9 +104,9 @@ public class SequentialCollectionTest {
 
       subject = new SequentialCollection(anyDescription());
       subject.addSpec(spec);
-      subject.runSpecs(reporter);
+      subject.runSpecs(observer);
 
-      Mockito.verify(spec).run(reporter);
+      Mockito.verify(spec).run(observer);
     }
 
     @Test
@@ -117,7 +117,7 @@ public class SequentialCollectionTest {
       subject = new SequentialCollection(anyDescription());
       subject.addSpec(addedFirst);
       subject.addSpec(addedSecond);
-      subject.runSpecs(reporter);
+      subject.runSpecs(observer);
 
       InOrder order = Mockito.inOrder(addedFirst, addedSecond);
       order.verify(addedFirst).run(Mockito.any());
@@ -133,11 +133,11 @@ public class SequentialCollectionTest {
       subject = new SequentialCollection(anyDescription());
       subject.addSubCollection(firstChild);
       subject.addSubCollection(secondChild);
-      subject.runSpecs(reporter);
+      subject.runSpecs(observer);
 
       InOrder order = Mockito.inOrder(firstChild, secondChild);
-      order.verify(firstChild).runSpecs(reporter);
-      order.verify(secondChild).runSpecs(reporter);
+      order.verify(firstChild).runSpecs(observer);
+      order.verify(secondChild).runSpecs(observer);
       order.verifyNoMoreInteractions();
     }
 
@@ -149,11 +149,11 @@ public class SequentialCollectionTest {
       subject = new SequentialCollection(anyDescription());
       subject.addSpec(spec);
       subject.addSubCollection(subCollection);
-      subject.runSpecs(reporter);
+      subject.runSpecs(observer);
 
       InOrder order = Mockito.inOrder(subCollection, spec);
-      order.verify(spec).run(reporter);
-      order.verify(subCollection).runSpecs(reporter);
+      order.verify(spec).run(observer);
+      order.verify(subCollection).runSpecs(observer);
       order.verifyNoMoreInteractions();
     }
 

--- a/doc/design-log.md
+++ b/doc/design-log.md
@@ -12,8 +12,8 @@ Technical debt:
 
 Features:
 
-- Help command.
-- Handle a run command that can't load a class.
+- Formatted test output.
+- Documented (tested) error reporting for things like not being able to find/load/instantiate a spec class.
   It may be helpful to return a value type for the exit status, instead of a just the number, so the offending class can
   be reported.
 - Report spec failures to the console reporter.

--- a/features/command_line.feature
+++ b/features/command_line.feature
@@ -8,18 +8,21 @@ Feature: JavaSpec CLI (external process)
   In order to have confidence that the whole system is wired up correctly
   I want to run JavaSpec as its own process and observe its behavior from a separate test process
 
-@wip
+@wip @focus
   Scenario: The CLI should offer to help when it's run without any arguments
     Given I have a JavaSpec runner for the console
     When I run the runner without any arguments
     Then the runner's exit status should be 0
     And the runner's output should be
     """
-    Usage: javaspec <command> [<args>]
+    Usage: javaspec <command> [<arguments>]
 
     Commands:
-      help    show this help
-      run     run specs in Java classes
+      help
+        show this help
+
+      run <spec class name> [spec class name...]
+        run specs in Java classes
     """
 
 

--- a/features/command_line.feature
+++ b/features/command_line.feature
@@ -8,7 +8,7 @@ Feature: JavaSpec CLI (external process)
   In order to have confidence that the whole system is wired up correctly
   I want to run JavaSpec as its own process and observe its behavior from a separate test process
 
-@wip @focus
+
   Scenario: The CLI should offer to help when it's run without any arguments
     Given I have a JavaSpec runner for the console
     When I run the runner without any arguments

--- a/features/step_definitions/command_line_steps.rb
+++ b/features/step_definitions/command_line_steps.rb
@@ -74,7 +74,8 @@ Then(/^the runner's exit status should be 0$/) do
 end
 
 Then(/^the runner's output should be$/) do |text|
-  expect(spec_runner_helper.runner_output).to eq(text)
+  # Somehow the Gherkin docstring doesn't end in a newline, even though it's there
+  expect(spec_runner_helper.runner_output.rstrip).to eq(text)
 end
 
 Then(/^The runner should describe what is being tested$/) do


### PR DESCRIPTION
(Finish) implementing the `javaspec help` command.

Aside from now having two whole commands you can run, this:

- further clarifies the use of the Observer pattern, where each `Command` has its own observer.
- formalizes the notion of a `Reporter` being an "observer of all things" -- i.e. any `Reporter` has to implement each one of the `Observer` interfaces.