### PR TITLE
Print error message instead of stack trace on CLI parse error

### DIFF
--- a/lambdas-and-strings/Rakefile
+++ b/lambdas-and-strings/Rakefile
@@ -36,6 +36,17 @@ namespace :distribution do
     ln_s "#{installed_dir}/bin/javaspec", installed_link unless File.exist? installed_link
   end
 
+  desc 'Run the distribution on a known spec class'
+  task :run do
+    sh *%W[
+        javaspec
+        run
+        --reporter=plaintext
+        --spec-classpath=#{spec_classpath}
+        info.javaspec.example.rb.SpringOperatedBoxingGloveSpecs
+      ]
+  end
+
   desc 'Remove the distribution from /usr/local'
   task :uninstall do
     rm installed_link if File.exist? installed_link
@@ -47,6 +58,10 @@ namespace :distribution do
 
   def distribution_path
     'console-runner/build/distributions/javaspec-2.0.0-SNAPSHOT.tar'
+  end
+
+  def spec_classpath
+    'examples/build/classes/java/main'
   end
 
   def untar(file, target_dir)

--- a/lambdas-and-strings/console-runner-features/src/test/java/info/javaspec/MockReporter.java
+++ b/lambdas-and-strings/console-runner-features/src/test/java/info/javaspec/MockReporter.java
@@ -1,5 +1,6 @@
 package info.javaspec;
 
+import info.javaspec.console.Exceptions.InvalidArguments;
 import info.javaspec.console.Reporter;
 
 import java.util.LinkedList;
@@ -79,4 +80,7 @@ public final class MockReporter implements Reporter {
 
   @Override
   public void commandFailed(Exception failure) { }
+
+  @Override
+  public void invalidArguments(InvalidArguments failure) { }
 }

--- a/lambdas-and-strings/console-runner-features/src/test/java/info/javaspec/console/MainSteps.java
+++ b/lambdas-and-strings/console-runner-features/src/test/java/info/javaspec/console/MainSteps.java
@@ -34,7 +34,8 @@ public class MainSteps {
     this.execRunCommand = () -> {
       OneOfEachSpecs.reset();
       Main.main(
-        Main.cliArgumentParser(new StaticCommandFactory(), () -> this.mockReporter), () -> this.mockReporter,
+        ArgumentParserFactory.forConsole(new StaticCommandFactory(), () -> this.mockReporter),
+        () -> this.mockReporter,
         this.system,
         "run",
         "--reporter=plaintext",
@@ -53,7 +54,8 @@ public class MainSteps {
   @Given("^I have a Java class that defines a suite of passing lambda specs$")
   public void iHaveAJavaClassThatDefinesPassingLambdaSpecs() throws Exception {
     this.execRunCommand = () -> Main.main(
-      Main.cliArgumentParser(new StaticCommandFactory(), () -> this.mockReporter), () -> this.mockReporter,
+      ArgumentParserFactory.forConsole(new StaticCommandFactory(), () -> this.mockReporter),
+      () -> this.mockReporter,
       this.system,
       "run",
       "--reporter=plaintext",
@@ -65,7 +67,8 @@ public class MainSteps {
   @Given("^I have a Java class that defines a suite of 1 or more failing lambda specs$")
   public void iHaveAClassWithFailingSpecs() throws Exception {
     this.execRunCommand = () -> Main.main(
-      Main.cliArgumentParser(new StaticCommandFactory(), () -> this.mockReporter), () -> this.mockReporter,
+      ArgumentParserFactory.forConsole(new StaticCommandFactory(), () -> this.mockReporter),
+      () -> this.mockReporter,
       this.system,
       "run",
       "--reporter=plaintext",

--- a/lambdas-and-strings/console-runner-features/src/test/java/info/javaspec/console/MainSteps.java
+++ b/lambdas-and-strings/console-runner-features/src/test/java/info/javaspec/console/MainSteps.java
@@ -34,7 +34,7 @@ public class MainSteps {
     this.execRunCommand = () -> {
       OneOfEachSpecs.reset();
       Main.main(
-        () -> this.mockReporter,
+        Main.cliArgumentParser(new StaticCommandFactory(), () -> this.mockReporter), () -> this.mockReporter,
         this.system,
         "run",
         "--reporter=plaintext",
@@ -53,7 +53,7 @@ public class MainSteps {
   @Given("^I have a Java class that defines a suite of passing lambda specs$")
   public void iHaveAJavaClassThatDefinesPassingLambdaSpecs() throws Exception {
     this.execRunCommand = () -> Main.main(
-      () -> this.mockReporter,
+      Main.cliArgumentParser(new StaticCommandFactory(), () -> this.mockReporter), () -> this.mockReporter,
       this.system,
       "run",
       "--reporter=plaintext",
@@ -65,7 +65,7 @@ public class MainSteps {
   @Given("^I have a Java class that defines a suite of 1 or more failing lambda specs$")
   public void iHaveAClassWithFailingSpecs() throws Exception {
     this.execRunCommand = () -> Main.main(
-      () -> this.mockReporter,
+      Main.cliArgumentParser(new StaticCommandFactory(), () -> this.mockReporter), () -> this.mockReporter,
       this.system,
       "run",
       "--reporter=plaintext",

--- a/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/ArgumentParserFactory.java
+++ b/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/ArgumentParserFactory.java
@@ -1,0 +1,13 @@
+package info.javaspec.console;
+
+import info.javaspec.console.help.HelpParameters;
+import info.javaspec.lang.lambda.RunParameters;
+
+class ArgumentParserFactory {
+  public static Main.ArgumentParser forConsole(CommandFactory commandFactory, ReporterFactory reporterFactory) {
+    MainParameters mainParameters = new MainParameters(commandFactory, reporterFactory);
+    return new MultiCommandParser("javaspec", mainParameters)
+      .addCliCommand("help", new HelpParameters(commandFactory, reporterFactory))
+      .addCliCommand("run", new RunParameters(commandFactory, reporterFactory));
+  }
+}

--- a/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Exceptions.java
+++ b/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Exceptions.java
@@ -2,7 +2,7 @@ package info.javaspec.console;
 
 import com.beust.jcommander.ParameterException;
 
-final class Exceptions {
+public final class Exceptions {
   static final class CommandAlreadyAdded extends RuntimeException {
     public static CommandAlreadyAdded named(String command) {
       return new CommandAlreadyAdded(String.format("Command has already been added: %s", command));
@@ -13,7 +13,7 @@ final class Exceptions {
     }
   }
 
-  static final class InvalidArguments extends RuntimeException {
+  public static final class InvalidArguments extends RuntimeException {
     public static InvalidArguments dueTo(ParameterException cause) {
       return new InvalidArguments(cause.getMessage(), cause);
     }

--- a/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Main.java
+++ b/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Main.java
@@ -1,8 +1,6 @@
 package info.javaspec.console;
 
 import info.javaspec.console.Exceptions.InvalidArguments;
-import info.javaspec.console.help.HelpParameters;
-import info.javaspec.lang.lambda.RunParameters;
 
 import java.util.Arrays;
 import java.util.List;
@@ -15,7 +13,7 @@ public final class Main {
     //Responsible just for wiring things up with concrete classes.  Delegates all behavior, to make it testable.
     ReporterFactory reporterFactory = new StaticReporterFactory(System.out);
     main(
-      cliArgumentParser(new StaticCommandFactory(), reporterFactory),
+      ArgumentParserFactory.forConsole(new StaticCommandFactory(), reporterFactory),
       reporterFactory,
       System::exit,
       args
@@ -35,13 +33,6 @@ public final class Main {
 
     Main cli = new Main(reporterFactory.plainTextReporter(), system);
     cli.runCommand(runnableCommand);
-  }
-
-  static ArgumentParser cliArgumentParser(CommandFactory commandFactory, ReporterFactory reporterFactory) {
-    MainParameters mainParameters = new MainParameters(commandFactory, reporterFactory);
-    return new MultiCommandParser("javaspec", mainParameters)
-      .addCliCommand("help", new HelpParameters(commandFactory, reporterFactory))
-      .addCliCommand("run", new RunParameters(commandFactory, reporterFactory));
   }
 
   private Main(Reporter reporter, ExitHandler system) {

--- a/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Main.java
+++ b/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Main.java
@@ -1,5 +1,6 @@
 package info.javaspec.console;
 
+import info.javaspec.console.Exceptions.InvalidArguments;
 import info.javaspec.console.help.HelpParameters;
 import info.javaspec.lang.lambda.RunParameters;
 
@@ -26,8 +27,8 @@ public final class Main {
     Command runnableCommand = null;
     try {
       runnableCommand = cliParser.parseCommand(Arrays.asList(args));
-    } catch (Exception e) {
-      System.err.println("run: The following options are required: [--reporter], [--spec-classpath]");
+    } catch (InvalidArguments e) {
+      reporterFactory.plainTextReporter().invalidArguments(e);
       system.exit(1);
       return; //Runs during a test, but not during production (suggesting that Result be passed upwards)
     }

--- a/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Main.java
+++ b/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Main.java
@@ -11,7 +11,7 @@ public final class Main {
   private final ExitHandler system;
 
   public static void main(String... args) {
-    //Just wire things up with concrete classes.  Delegate all action, to make it testable.
+    //Responsible just for wiring things up with concrete classes.  Delegates all behavior, to make it testable.
     ReporterFactory reporterFactory = new StaticReporterFactory(System.out);
     main(
       cliArgumentParser(new StaticCommandFactory(), reporterFactory),
@@ -22,7 +22,7 @@ public final class Main {
   }
 
   static void main(ArgumentParser cliParser, ReporterFactory reporterFactory, ExitHandler system, String... args) {
-    //Enable testing with doubles by doing all logic (even if messy) via interfaces
+    //Responsible for enabling testing with doubles by doing all logic (even if messy) via interfaces
     Command runnableCommand = null;
     try {
       runnableCommand = cliParser.parseCommand(Arrays.asList(args));
@@ -43,12 +43,12 @@ public final class Main {
       .addCliCommand("run", new RunParameters(commandFactory, reporterFactory));
   }
 
-  Main(Reporter reporter, ExitHandler system) {
+  private Main(Reporter reporter, ExitHandler system) {
     this.reporter = reporter;
     this.system = system;
   }
 
-  void runCommand(Command command) {
+  private void runCommand(Command command) {
     Result result = command.run();
     result.reportTo(this.reporter);
     this.system.exit(result.exitCode);

--- a/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Main.java
+++ b/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Main.java
@@ -28,14 +28,15 @@ public final class Main {
       runnableCommand = cliParser.parseCommand(Arrays.asList(args));
     } catch (Exception e) {
       System.err.println("run: The following options are required: [--reporter], [--spec-classpath]");
-      System.exit(1);
+      system.exit(1);
+      return; //Runs during a test, but not during production (suggesting that Result be passed upwards)
     }
 
     Main cli = new Main(reporterFactory.plainTextReporter(), system);
     cli.runCommand(runnableCommand);
   }
 
-  private static ArgumentParser cliArgumentParser(CommandFactory commandFactory, ReporterFactory reporterFactory) {
+  static ArgumentParser cliArgumentParser(CommandFactory commandFactory, ReporterFactory reporterFactory) {
     MainParameters mainParameters = new MainParameters(commandFactory, reporterFactory);
     return new MultiCommandParser("javaspec", mainParameters)
       .addCliCommand("help", new HelpParameters(commandFactory, reporterFactory))

--- a/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Main.java
+++ b/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Main.java
@@ -11,17 +11,18 @@ public final class Main {
   private final ExitHandler system;
 
   public static void main(String... args) {
+    //Just wire things up with concrete classes.  Delegate all action, to make it testable.
+    ReporterFactory reporterFactory = new StaticReporterFactory(System.out);
     main(
-      new StaticReporterFactory(System.out),
+      cliArgumentParser(new StaticCommandFactory(), reporterFactory),
+      reporterFactory,
       System::exit,
       args
     );
   }
 
-  static void main(ReporterFactory reporterFactory, ExitHandler system, String... args) {
-    ArgumentParser cliParser = cliArgumentParser(new StaticCommandFactory(), reporterFactory);
-    Main cli = new Main(reporterFactory.plainTextReporter(), system);
-
+  static void main(ArgumentParser cliParser, ReporterFactory reporterFactory, ExitHandler system, String... args) {
+    //Enable testing with doubles by doing all logic (even if messy) via interfaces
     Command runnableCommand = null;
     try {
       runnableCommand = cliParser.parseCommand(Arrays.asList(args));
@@ -30,6 +31,7 @@ public final class Main {
       System.exit(1);
     }
 
+    Main cli = new Main(reporterFactory.plainTextReporter(), system);
     cli.runCommand(runnableCommand);
   }
 

--- a/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Main.java
+++ b/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Main.java
@@ -21,7 +21,16 @@ public final class Main {
   static void main(ReporterFactory reporterFactory, ExitHandler system, String... args) {
     ArgumentParser cliParser = cliArgumentParser(new StaticCommandFactory(), reporterFactory);
     Main cli = new Main(reporterFactory.plainTextReporter(), system);
-    cli.runCommand(cliParser.parseCommand(Arrays.asList(args)));
+
+    Command runnableCommand = null;
+    try {
+      runnableCommand = cliParser.parseCommand(Arrays.asList(args));
+    } catch (Exception e) {
+      System.err.println("run: The following options are required: [--reporter], [--spec-classpath]");
+      System.exit(1);
+    }
+
+    cli.runCommand(runnableCommand);
   }
 
   private static ArgumentParser cliArgumentParser(CommandFactory commandFactory, ReporterFactory reporterFactory) {

--- a/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Reporter.java
+++ b/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/Reporter.java
@@ -1,9 +1,12 @@
 package info.javaspec.console;
 
 import info.javaspec.RunObserver;
+import info.javaspec.console.Exceptions.InvalidArguments;
 import info.javaspec.console.help.HelpObserver;
 
 /** An observer of all things, that handles reporting when running commands. */
 public interface Reporter extends HelpObserver, RunObserver {
   void commandFailed(Exception failure);
+
+  void invalidArguments(InvalidArguments failure);
 }

--- a/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/plaintext/PlainTextReporter.java
+++ b/lambdas-and-strings/console-runner/src/main/java/info/javaspec/console/plaintext/PlainTextReporter.java
@@ -2,6 +2,7 @@ package info.javaspec.console.plaintext;
 
 import info.javaspec.Spec;
 import info.javaspec.SpecCollection;
+import info.javaspec.console.Exceptions.InvalidArguments;
 import info.javaspec.console.Reporter;
 
 import java.io.PrintStream;
@@ -119,6 +120,11 @@ public final class PlainTextReporter implements Reporter {
 
   @Override
   public void commandFailed(Exception failure) {
+    this.output.println(failure.getMessage());
+  }
+
+  @Override
+  public void invalidArguments(InvalidArguments failure) {
     this.output.println(failure.getMessage());
   }
 }

--- a/lambdas-and-strings/console-runner/src/test/java/info/javaspec/console/MainTest.java
+++ b/lambdas-and-strings/console-runner/src/test/java/info/javaspec/console/MainTest.java
@@ -41,6 +41,18 @@ public class MainTest {
       public void doesNotExplode_whichIsAlwaysAPlus() throws Exception {
         Main.main(cliParser, reporterFactory, system);
       }
+
+      @Test @Ignore
+      public void runsTheCommand() throws Exception {
+      }
+
+      @Test @Ignore
+      public void reportsTheResult() throws Exception {
+      }
+
+      @Test @Ignore
+      public void exitsWithWhateverResultCodeIsReturned() throws Exception {
+      }
     }
 
     public class givenInvalidArguments {

--- a/lambdas-and-strings/console-runner/src/test/java/info/javaspec/console/MainTest.java
+++ b/lambdas-and-strings/console-runner/src/test/java/info/javaspec/console/MainTest.java
@@ -33,6 +33,8 @@ public class MainTest {
 
         reporterFactory = Mockito.mock(ReporterFactory.class);
         reporter = Mockito.mock(Reporter.class);
+        Mockito.stub(reporterFactory.plainTextReporter())
+          .toReturn(reporter);
 
         system = Mockito.mock(Main.ExitHandler.class);
       }
@@ -42,16 +44,27 @@ public class MainTest {
         Main.main(cliParser, reporterFactory, system);
       }
 
-      @Test @Ignore
+      @Test
       public void runsTheCommand() throws Exception {
+        Mockito.stub(command.run()).toReturn(Result.success());
+        Main.main(cliParser, reporterFactory, system);
+        Mockito.verify(command, Mockito.times(1)).run();
       }
 
-      @Test @Ignore
+      @Test
+      public void exitsWithTheExitCodeReturnedByTheCommand() throws Exception {
+        Result failure = Result.failure(42, "...you're not going to like it.");
+        Mockito.stub(command.run()).toReturn(failure);
+        Main.main(cliParser, reporterFactory, system);
+        Mockito.verify(system, Mockito.times(1)).exit(42);
+      }
+
+      @Test
       public void reportsTheResult() throws Exception {
-      }
-
-      @Test @Ignore
-      public void exitsWithWhateverResultCodeIsReturned() throws Exception {
+        Result result = Mockito.mock(Result.class);
+        Mockito.stub(command.run()).toReturn(result);
+        Main.main(cliParser, reporterFactory, system);
+        Mockito.verify(result).reportTo(Mockito.same(reporter));
       }
     }
 
@@ -71,18 +84,6 @@ public class MainTest {
         system = Mockito.mock(Main.ExitHandler.class);
       }
 
-      @Test @Ignore
-      public void shouldReportAnErrorMessage() throws Exception {
-      }
-
-      @Test
-      public void shouldCallTheSystemInterfaceWhenItBombs() throws Exception {
-        Mockito.doThrow(new RuntimeException("bang!"))
-          .when(cliParser).parseCommand(matchAnyArguments());
-        Main.main(cliParser, reporterFactory, system);
-        Mockito.verify(system).exit(1);
-      }
-
       @Test
       public void shouldNotRunTheCommand() throws Exception {
         Mockito.doThrow(new RuntimeException("bang!"))
@@ -90,41 +91,18 @@ public class MainTest {
         Main.main(cliParser, reporterFactory, system);
         Mockito.verifyZeroInteractions(command);
       }
-    }
-  }
 
-  public class runCommand {
-    private Main subject;
+      @Test @Ignore
+      public void shouldReportAnErrorMessage() throws Exception {
+      }
 
-    @Before
-    public void setup() {
-      reporter = Mockito.mock(Reporter.class);
-      system = Mockito.mock(Main.ExitHandler.class);
-      subject = new Main(reporter, system);
-      command = Mockito.mock(Command.class);
-    }
-
-    @Test
-    public void runsTheCommand() throws Exception {
-      Mockito.stub(command.run()).toReturn(Result.success());
-      subject.runCommand(command);
-      Mockito.verify(command, Mockito.times(1)).run();
-    }
-
-    @Test
-    public void exitsWithTheExitCodeReturnedByTheCommand() throws Exception {
-      Result failure = Result.failure(42, "...you're not going to like it.");
-      Mockito.stub(command.run()).toReturn(failure);
-      subject.runCommand(command);
-      Mockito.verify(system, Mockito.times(1)).exit(42);
-    }
-
-    @Test
-    public void reportsTheResult() throws Exception {
-      Result result = Mockito.mock(Result.class);
-      Mockito.stub(command.run()).toReturn(result);
-      subject.runCommand(command);
-      Mockito.verify(result).reportTo(Mockito.same(reporter));
+      @Test
+      public void shouldExitWithTheProvidedSystemInterface() throws Exception {
+        Mockito.doThrow(new RuntimeException("bang!"))
+          .when(cliParser).parseCommand(matchAnyArguments());
+        Main.main(cliParser, reporterFactory, system);
+        Mockito.verify(system).exit(1);
+      }
     }
   }
 

--- a/lambdas-and-strings/console-runner/src/test/java/info/javaspec/console/MainTest.java
+++ b/lambdas-and-strings/console-runner/src/test/java/info/javaspec/console/MainTest.java
@@ -2,6 +2,7 @@ package info.javaspec.console;
 
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -12,6 +13,7 @@ import java.util.List;
 public class MainTest {
   private Main.ArgumentParser cliParser;
   private Command command;
+  private Result result;
 
   private ReporterFactory reporterFactory;
   private Reporter reporter;
@@ -19,31 +21,63 @@ public class MainTest {
   private Main.ExitHandler system;
 
   public class main {
-    @Before
-    public void setup() {
-      cliParser = Mockito.mock(Main.ArgumentParser.class);
-      command = Mockito.mock(Command.class);
-      Mockito.stub(cliParser.parseCommand(matchAnyArguments()))
-        .toReturn(command);
-      Mockito.stub(command.run()).toReturn(anyResult());
+    public class givenValidArguments {
+      @Before
+      public void setup() {
+        cliParser = Mockito.mock(Main.ArgumentParser.class);
+        command = Mockito.mock(Command.class);
+        result = Mockito.mock(Result.class);
+        Mockito.stub(cliParser.parseCommand(matchAnyArguments()))
+          .toReturn(command);
+        Mockito.stub(command.run()).toReturn(result);
 
-      reporterFactory = Mockito.mock(ReporterFactory.class);
-      reporter = Mockito.mock(Reporter.class);
+        reporterFactory = Mockito.mock(ReporterFactory.class);
+        reporter = Mockito.mock(Reporter.class);
 
-      system = Mockito.mock(Main.ExitHandler.class);
+        system = Mockito.mock(Main.ExitHandler.class);
+      }
+
+      @Test
+      public void doesNotExplode_whichIsAlwaysAPlus() throws Exception {
+        Main.main(cliParser, reporterFactory, system);
+      }
     }
 
-    @Test
-    public void runs() throws Exception {
-      Main.main(cliParser, reporterFactory, system);
-    }
+    public class givenInvalidArguments {
+      @Before
+      public void setup() {
+        cliParser = Mockito.mock(Main.ArgumentParser.class);
+        command = Mockito.mock(Command.class);
+        result = Mockito.mock(Result.class);
+        Mockito.stub(cliParser.parseCommand(matchAnyArguments()))
+          .toReturn(command);
+        Mockito.stub(command.run()).toReturn(result);
 
-    @Test
-    public void shouldCallTheSystemInterfaceWhenItBombs() throws Exception {
-      Mockito.doThrow(new RuntimeException("bang!"))
-        .when(cliParser).parseCommand(matchAnyArguments());
-      Main.main(cliParser, reporterFactory, system); //bombs
-      Mockito.verify(system).exit(1);
+        reporterFactory = Mockito.mock(ReporterFactory.class);
+        reporter = Mockito.mock(Reporter.class);
+
+        system = Mockito.mock(Main.ExitHandler.class);
+      }
+
+      @Test @Ignore
+      public void shouldReportAnErrorMessage() throws Exception {
+      }
+
+      @Test
+      public void shouldCallTheSystemInterfaceWhenItBombs() throws Exception {
+        Mockito.doThrow(new RuntimeException("bang!"))
+          .when(cliParser).parseCommand(matchAnyArguments());
+        Main.main(cliParser, reporterFactory, system);
+        Mockito.verify(system).exit(1);
+      }
+
+      @Test
+      public void shouldNotRunTheCommand() throws Exception {
+        Mockito.doThrow(new RuntimeException("bang!"))
+          .when(cliParser).parseCommand(matchAnyArguments());
+        Main.main(cliParser, reporterFactory, system);
+        Mockito.verifyZeroInteractions(command);
+      }
     }
   }
 

--- a/lambdas-and-strings/console-runner/src/test/java/info/javaspec/console/plaintext/PlainTextReporterTest.java
+++ b/lambdas-and-strings/console-runner/src/test/java/info/javaspec/console/plaintext/PlainTextReporterTest.java
@@ -1,8 +1,10 @@
 package info.javaspec.console.plaintext;
 
+import com.beust.jcommander.ParameterException;
 import de.bechte.junit.runners.context.HierarchicalContextRunner;
 import info.javaspec.Spec;
 import info.javaspec.SpecCollection;
+import info.javaspec.console.Exceptions;
 import info.javaspec.console.Reporter;
 import org.hamcrest.Matcher;
 import org.junit.Before;
@@ -121,8 +123,17 @@ public class PlainTextReporterTest {
 
   public class commandFailed {
     @Test
-    public void printsAStackTraceToTheGivenWriter() throws Exception {
+    public void printsJustTheErrorMessageToTheGivenWriter() throws Exception {
       subject.commandFailed(new RuntimeException("bang!"));
+
+      output.shouldHavePrintedExactly(equalTo("bang!"));
+    }
+  }
+
+  public class invalidArguments {
+    @Test
+    public void printsJustTheErrorMessageToTheGivenWriter() throws Exception {
+      subject.invalidArguments(Exceptions.InvalidArguments.dueTo(new ParameterException("bang!")));
 
       output.shouldHavePrintedExactly(equalTo("bang!"));
     }

--- a/lambdas-and-strings/features/command_line.feature
+++ b/lambdas-and-strings/features/command_line.feature
@@ -51,7 +51,6 @@ Feature: JavaSpec CLI (external process)
     Then The runner should indicate that 1 or more specs have failed
 
 
-  @focus
   Scenario: The CLI should suppress stack traces for an invalid command
     Given I have a JavaSpec runner for the console
     When I run the runner with an incomplete run command

--- a/lambdas-and-strings/features/command_line.feature
+++ b/lambdas-and-strings/features/command_line.feature
@@ -49,3 +49,14 @@ Feature: JavaSpec CLI (external process)
     And I have a Java class that defines a suite of 1 or more failing lambda specs
     When I run the specs in that class
     Then The runner should indicate that 1 or more specs have failed
+
+
+  @focus @wip
+  Scenario: The CLI should suppress stack traces for an invalid command
+    Given I have a JavaSpec runner for the console
+    When I run the runner with an incomplete run command
+    Then the runner's output should be
+    """
+    run: The following options are required: [--reporter], [--spec-classpath]
+    """
+    And the runner's exit status should be 1

--- a/lambdas-and-strings/features/command_line.feature
+++ b/lambdas-and-strings/features/command_line.feature
@@ -51,7 +51,7 @@ Feature: JavaSpec CLI (external process)
     Then The runner should indicate that 1 or more specs have failed
 
 
-  @focus @wip
+  @focus
   Scenario: The CLI should suppress stack traces for an invalid command
     Given I have a JavaSpec runner for the console
     When I run the runner with an incomplete run command

--- a/lambdas-and-strings/features/step_definitions/command_line_steps.rb
+++ b/lambdas-and-strings/features/step_definitions/command_line_steps.rb
@@ -12,6 +12,10 @@ Given(/^I have a Java class that defines a suite of 1 or more failing lambda spe
   spec_runner_helper.spec_classes = ['info.javaspec.example.rb.OneFailsSpecs']
 end
 
+When(/^I run the runner with an incomplete run command$/) do
+  spec_runner_helper.exec! logger, args: %w[run]
+end
+
 When(/^I run the runner without any arguments$/) do
   spec_runner_helper.exec! logger
 end
@@ -20,8 +24,8 @@ When(/^I run the specs in that class$/) do
   spec_runner_helper.exec_run! logger
 end
 
-Then(/^the runner's exit status should be 0$/) do
-  expect(spec_runner_helper.exit_status).to eq(0)
+Then(/^the runner's exit status should be (\d+)$/) do |expected_code|
+  expect(spec_runner_helper.exit_status).to eq(expected_code)
 end
 
 Then(/^the runner's output should be$/) do |expected_text|


### PR DESCRIPTION
Print a simple error message when failing to parse CLI arguments, instead of showing a noisy stack trace.

Also adds `rake distribution:run`, to ease running the CLI in a realistic manner.