### PR TITLE
Prototype beforeEach and afterEach

### DIFF
--- a/prototypes/docs/problems.md
+++ b/prototypes/docs/problems.md
@@ -25,6 +25,8 @@ as always, but also add a `TestFilter` to ignore it?
 * [ ] Defining a common setup procedure that runs before each spec in a container.
 * [ ] Defining a common teardown procedure that runs after each spec in a container.
 
+TODO KDK: Work here on trying out `beforeEach`.
+
 Declaring and instantiating the test subject was a point of friction with declaration-only syntax with static methods.
 There isn't a way to add static methods that return type-safe subjects in their own type, so this pushed the design
 towards instantiating a `JavaSpec<S>` instance and using that to declare all specs.  This allowed for the addition of

--- a/prototypes/docs/problems.md
+++ b/prototypes/docs/problems.md
@@ -3,12 +3,12 @@
 ## Writing Specs
 ### 1 - Syntax for defining specs
 
-* [x] Descriptions of expected behavior(s): `JavaSpec[#::]it`.
-* [x] Procedures to verify those expectations `JavaSpec[#::]it`.
-* [x] Description of what (class, method, or function) is being tested: `JavaSpec[#::]describe`.
-* [x] Description of any particular circumstances, during which those expectations apply: `JavaSpec[#::]context`.
-* [x] Disabled spec, that should not be run: `JavaSpec[#::]disabled`.
-* [x] Pending spec, that lacks a verification: `JavaSpec[#::]pending`.
+* [x] Descriptions of expected behavior(s): `JavaSpec#it`.
+* [x] Procedures to verify those expectations `JavaSpec#it`.
+* [x] Description of what (class, method, or function) is being tested: `JavaSpec#describe`.
+* [x] Description of any particular circumstances, during which those expectations apply: `JavaSpec#context`.
+* [x] Disabled spec, that should not be run: `JavaSpec#disabled`.
+* [x] Pending spec, that lacks a verification: `JavaSpec#pending`.
 
 `StaticMethodSyntax` shows concise JavaSpec syntax by using static imports for JavaSpec methods.  It's more concise–and
 there are fewer opportunities to mix up scope–than with passing scope/context parameters back to the lambdas.
@@ -22,10 +22,8 @@ as always, but also add a `TestFilter` to ignore it?
 * [x] Common instance/factory for generating the test subject: `JavaSpec<S>#subject`.
 * [x] Declaration of reused variables: Class fields, local variables (immutable), local atomic variables (mutable).
 * [x] Creating common data or instantiating collaborators: Extract helper functions.
-* [ ] Defining a common setup procedure that runs before each spec in a container.
+* [x] Defining a common setup procedure that runs before each spec in a container: `JavaSpec#beforeEach`.
 * [ ] Defining a common teardown procedure that runs after each spec in a container.
-
-TODO KDK: Work here on trying out `beforeEach`.
 
 Declaring and instantiating the test subject was a point of friction with declaration-only syntax with static methods.
 There isn't a way to add static methods that return type-safe subjects in their own type, so this pushed the design

--- a/prototypes/docs/problems.md
+++ b/prototypes/docs/problems.md
@@ -6,40 +6,81 @@
 * [x] Descriptions of expected behavior(s): `JavaSpec#it`.
 * [x] Procedures to verify those expectations `JavaSpec#it`.
 * [x] Description of what (class, method, or function) is being tested: `JavaSpec#describe`.
-* [x] Description of any particular circumstances, during which those expectations apply: `JavaSpec#context`.
+* [x] Description of any particular circumstances, during which those expectations apply:
+  `JavaSpec#context`.
 * [x] Disabled spec, that should not be run: `JavaSpec#disabled`.
 * [x] Pending spec, that lacks a verification: `JavaSpec#pending`.
 
-`StaticMethodSyntax` shows concise JavaSpec syntax by using static imports for JavaSpec methods.  It's more concise–and
-there are fewer opportunities to mix up scope–than with passing scope/context parameters back to the lambdas.
+`StaticMethodSyntax` shows concise JavaSpec syntax by using static imports for JavaSpec methods.
+It's more concise–and there are fewer opportunities to mix up scope–than with passing scope/context
+parameters back to the lambdas.
 
-The syntax for `disabled` is nice to write, but running it is quite misleading.  Could JavaSpec create the `DyanmicTest`
-as always, but also add a `TestFilter` to ignore it?
+The syntax for `disabled` is nice to write, but running it is quite misleading.  Could JavaSpec
+create the `DyanmicTest` as always, but also add a `TestFilter` to ignore it?
 
 
-### 2 - Syntax to help Arrange
+### 2 - Syntax to help Arrange and Clean
 
 * [x] Common instance/factory for generating the test subject: `JavaSpec<S>#subject`.
-* [x] Declaration of reused variables: Class fields, local variables (immutable), local atomic variables (mutable).
+* [x] Declaration of reused variables: Class fields, local variables (immutable), local atomic
+  variables (mutable).
 * [x] Creating common data or instantiating collaborators: Extract helper functions.
-* [x] Defining a common setup procedure that runs before each spec in a container: `JavaSpec#beforeEach`.
-* [x] Defining a common teardown procedure that runs after each spec in a container: `JavaSpec#afterEach`.
+* [x] Defining a common setup procedure that runs before each spec in a container:
+  `JavaSpec#beforeEach`.
+* [x] Defining a common teardown procedure that runs after each spec in a container:
+  `JavaSpec#afterEach`.
 
-Declaring and instantiating the test subject was a point of friction with declaration-only syntax with static methods.
-There isn't a way to add static methods that return type-safe subjects in their own type, so this pushed the design
-towards instantiating a `JavaSpec<S>` instance and using that to declare all specs.  This allowed for the addition of
-generic methods to declare and create test subjects.
+Declaring and instantiating the test subject was a point of friction with declaration-only syntax
+with static methods. There isn't a way to add static methods that return type-safe subjects in their
+own type, so this pushed the design towards instantiating a `JavaSpec<S>` instance and using that to
+declare all specs.  This allowed for the addition of generic methods to declare and create test
+subjects.
 
-What is the impact of using a `JavaSpec` instance instead of static methods?  While it is a little more verbose to
-declare and use the instance, it's not as distracting as I thought it would be.  It still remains posible to make a
-static wrapper (that tracks a thread- or class-local `JavaSpec` instance), if a more compact syntax is needed.  Such a
-wrapper would sacrifice the type-safe subject methods, however.
+What is the impact of using a `JavaSpec` instance instead of static methods?  While it is a little
+more verbose to declare and use the instance, it's not as distracting as I thought it would be.  It
+still remains possible to make a static wrapper (that tracks a thread- or class-local `JavaSpec`
+instance), if a more compact syntax is needed.  Such a wrapper would sacrifice the type-safe subject
+methods, however.
+
+It is possible to extend the instance-based (and likely also static-based) flavor of `JavaSpec` to
+support lambdas that run `beforeEach` and `afterEach`, just like you would see in Jasmine and RSpec.
+This supports arbitrary setup and teardown work to DRY test code and maintain a clean, known state
+for each spec.  It also has all the usual downsides of this approach, by making it harder to
+determine which code executes for any given spec.
+
+`ExUnit` does not allow [nested describe blocks](https://hexdocs.pm/ex_unit/ExUnit.Case.html), and
+that design pressure was pretty helpful during my tenure in Elixir.
+
+> Note describe blocks cannot be nested. Instead of relying on hierarchy for composition, developers
+> should build on top of named setups.
+> ...
+> By forbidding hierarchies in favor of named setups, it is straightforward for the developer to
+> glance at each describe block and know exactly the setup steps involved.
+
+The downside, is that it's not clear how to implement such careful scoping without having distinct
+objects per scope (a top-level one that allows `#describe` and all others which omit `#describe`),
+without the kind of fine-grained syntax that seems to be possible with Elixir.  While that behavior
+could be implemented at runtime, that seems like a recipe for lots of unexpected exceptions (and
+frustration) when using `JavaSpec`.  So I think the right balance here is to advocate for less
+nesting while still allowing developers full flexibility to develop their own style.
+
+Finally, the whole thing with setting a variable's value in one lambda (`beforeEach`) and accessing
+it in a spec (`it`) is more of a cognitive load–at least in theory–than I was hoping.  In practice,
+it seems like a simple call to `AtomicReference#set` and `AtomicReference#get` is enough to get by,
+by this will need some verification in cases where Jupiter runs specs in parallel (does it just
+_run_ them in parallel, or does it _declare_ them in parallel too?).  It will also require an
+example or two for developers–like me–who never had to use `AtomicReference` before.
+
+`#subject` is still the way I prefer to declare the instance under test, but this `AtomicReference`
+usage is likely to come up when instantiating collaborators, at the very least.  And not everybody
+is on the `subject` train.
 
 
 ### Where in a spec class to use this syntax, to declare specs
 
 * [ ] Jupiter-tagged test factory method
-* [ ] Implement a method from a `JavaSpec` base class, that is wired up to a Jupiter-tagged test factory method
+* [ ] Implement a method from a `JavaSpec` base class, that is wired up to a Jupiter-tagged test
+  factory method
 * [ ] Constructor
 * [ ] Instance initializer
 * [ ] Static initializer (ew)
@@ -50,7 +91,8 @@ wrapper would sacrifice the type-safe subject methods, however.
 ### How to run specs, in IntelliJ
 
 * [ ] Gradle test runner: Does not show `@DisplayName`, for regular Jupiter syntax.
-* [ ] IntelliJ test runner: Works for `@DisplayName` in Jupiter syntax, and working so far for `DynamicTest`.
+* [ ] IntelliJ test runner: Works for `@DisplayName` in Jupiter syntax, and working so far for
+  `DynamicTest`.
 
 
 ### How to run specs, on the command line
@@ -61,17 +103,18 @@ wrapper would sacrifice the type-safe subject methods, however.
 
 ### How to run specs, in CI
 
-> Is running in CI _exactly_ the same as regular, command-line usage, or are could there be subtle differences?
+> Is running in CI _exactly_ the same as regular, command-line usage, or are could there be subtle
+> differences?
 
 
 ### How to report results
 
-* [ ] Finding exceptions that happen in the production code and exceptions that happen in the test code, and tracing
-  back from the stack trace to both.
+* [ ] Finding exceptions that happen in the production code and exceptions that happen in the test
+  code, and tracing back from the stack trace to both.
 * [ ] On the command-line: The Jupiter standalone jar would be best
 * [ ] When running on the command-line, during CI
-* [ ] When running in Gradle: Uhh...use the built-in test reporter?  Compatible with custom reporters? Write our own
-  custom reporter?
+* [ ] When running in Gradle: Uhh...use the built-in test reporter?  Compatible with custom
+  reporters? Write our own custom reporter?
 * [ ] When running in IntelliJ: IntelliJ Test Runner seems to be handling Jupiter syntax ok, so far.
 
 
@@ -100,4 +143,5 @@ wrapper would sacrifice the type-safe subject methods, however.
 ### Where to store specs and/or Jupiter test objects (`DynamicNode`)
 
 * [ ] JavaSpec singleton: Might work as long as only 1 spec class is declaring at a time.
-* [ ] JavaSpec "class-local": Something like `ThreadLocal`, but tied to the calling test class instead of to a thread.
+* [ ] JavaSpec "class-local": Something like `ThreadLocal`, but tied to the calling test class
+  instead of to a thread.

--- a/prototypes/docs/problems.md
+++ b/prototypes/docs/problems.md
@@ -23,7 +23,7 @@ as always, but also add a `TestFilter` to ignore it?
 * [x] Declaration of reused variables: Class fields, local variables (immutable), local atomic variables (mutable).
 * [x] Creating common data or instantiating collaborators: Extract helper functions.
 * [x] Defining a common setup procedure that runs before each spec in a container: `JavaSpec#beforeEach`.
-* [ ] Defining a common teardown procedure that runs after each spec in a container.
+* [x] Defining a common teardown procedure that runs after each spec in a container: `JavaSpec#afterEach`.
 
 Declaring and instantiating the test subject was a point of friction with declaration-only syntax with static methods.
 There isn't a way to add static methods that return type-safe subjects in their own type, so this pushed the design

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
@@ -19,13 +19,16 @@ public class FixtureMethodSpecs {
   DynamicNode beforeEachSingle() {
     JavaSpec greeterSpecs = new JavaSpec();
     return greeterSpecs.describe(Greeter.class, () -> {
+      //Negative: Can't just set in a beforeEach and access in it, without thinking about what "volatile" means.
       AtomicReference<Greeter> subject = new AtomicReference<>();
 
+      //Positive: beforeEach runs as expected, just before each spec.
       //Unknown: What happens if #beforeEach is called after #it?
       greeterSpecs.beforeEach(() -> {
         subject.set(new Greeter());
       });
 
+      //Positive: It is possible to access fields that are assigned in beforeEach, as long as you use AtomicReference.
       greeterSpecs.it("greets the world", () -> {
         assertEquals("Hello world!", subject.get().makeGreeting());
       });
@@ -47,6 +50,8 @@ public class FixtureMethodSpecs {
       });
 
       specs.context("when the list has 1 or more elements", () -> {
+        //Positive: Nested beforeEach blocks do work, in a manner similar to Jasmine and RSpec.
+        //Negative: Multiple beforeEach blocks can be abused, as with Jasmine and RSpec.
         specs.beforeEach(() -> {
           subject.get().add("existing");
         });
@@ -63,6 +68,7 @@ public class FixtureMethodSpecs {
   DynamicNode afterEachSingle() {
     JavaSpec sloppySpecs = new JavaSpec();
     return sloppySpecs.describe(Greeter.class, () -> {
+      //Positive: afterEach works too.
       sloppySpecs.afterEach(() -> {
         TestObject.sharedState = null;
       });

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
@@ -40,6 +40,26 @@ public class FixtureMethodSpecs {
   }
 
   @TestFactory
+  DynamicNode beforeEachExample() {
+    JavaSpec<List<String>> specs = new JavaSpec<>();
+    return specs.describe(List.class, () -> {
+      specs.subject(() -> new LinkedList<>());
+
+      specs.context("when the list has 1 or more elements", () -> {
+        specs.beforeEach(() -> {
+          specs.subject().add("existing");
+        });
+
+        specs.it("appends to the tail", () -> {
+          List<String> subject = specs.subject();
+          subject.add("appended");
+          assertEquals(Arrays.asList("existing", "appended"), subject);
+        });
+      });
+    });
+  }
+
+  @TestFactory
   DynamicNode beforeEachMultiple() {
     JavaSpec specs = new JavaSpec();
     return specs.describe(List.class, () -> {

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
@@ -42,19 +42,15 @@ public class FixtureMethodSpecs {
       AtomicReference<List<String>> subject = new AtomicReference<>();
 
       specs.beforeEach(() -> {
-        //TODO KDK: Work here to get this beforeEach called in the it two levels below
-        System.out.println("beforeEach describe/List");
         subject.set(new LinkedList<>());
       });
 
       specs.context("when the list has 1 or more elements", () -> {
         specs.beforeEach(() -> {
-          System.out.println("beforeEach context/1+");
           subject.get().add("existing");
         });
 
         specs.it("appends to the tail", () -> {
-          System.out.println("it/appends");
           subject.get().add("appended");
           assertEquals(Arrays.asList("existing", "appended"), subject.get());
         });

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
@@ -1,0 +1,29 @@
+package info.javaspec.jupiter.syntax.fixture;
+
+import info.javaspec.jupiter.Greeter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("Fixture syntax: Methods on JavaSpec instance")
+public class FixtureMethodSpecs {
+  @TestFactory
+  DynamicNode makeSpecs() {
+    JavaSpec greeterSpecs = new JavaSpec();
+    return greeterSpecs.describe(Greeter.class, () -> {
+      AtomicReference<Greeter> subject = new AtomicReference<>();
+
+      greeterSpecs.beforeEach(() -> {
+        subject.set(new Greeter());
+      });
+
+      greeterSpecs.it("Greets the world", () -> {
+        assertEquals("Hello world!", subject.get().makeGreeting());
+      });
+    });
+  }
+}

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @DisplayName("Fixture syntax: Methods on JavaSpec instance")
 public class FixtureMethodSpecs {
@@ -56,5 +57,31 @@ public class FixtureMethodSpecs {
         });
       });
     });
+  }
+
+  @TestFactory
+  DynamicNode afterEachSingle() {
+    JavaSpec sloppySpecs = new JavaSpec();
+    return sloppySpecs.describe(Greeter.class, () -> {
+      sloppySpecs.afterEach(() -> {
+        TestObject.sharedState = null;
+      });
+
+      sloppySpecs.it("sets a static variable once", () -> {
+        assertNull(TestObject.sharedState);
+        TestObject.sharedState = "One";
+        assertEquals("One", TestObject.sharedState);
+      });
+
+      sloppySpecs.it("sets a static variable twice", () -> {
+        assertNull(TestObject.sharedState);
+        TestObject.sharedState = "Other";
+        assertEquals("Other", TestObject.sharedState);
+      });
+    });
+  }
+
+  private static final class TestObject {
+    public static String sharedState;
   }
 }

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
@@ -17,18 +17,16 @@ public class FixtureMethodSpecs {
     return greeterSpecs.describe(Greeter.class, () -> {
       AtomicReference<Greeter> subject = new AtomicReference<>();
 
+      //Unknown: What happens if #beforeEach is called after #it?
       greeterSpecs.beforeEach(() -> {
-        System.out.println("beforeEach");
         subject.set(new Greeter());
       });
 
-      greeterSpecs.it("Greets the world", () -> {
-        System.out.println("it makeGreeting/0");
+      greeterSpecs.it("greets the world", () -> {
         assertEquals("Hello world!", subject.get().makeGreeting());
       });
 
-      greeterSpecs.it("Greets a person by name", () -> {
-        System.out.println("it makeGreeting/1");
+      greeterSpecs.it("greets a person by name", () -> {
         assertEquals("Hello George!", subject.get().makeGreeting("George"));
       });
     });

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.TestFactory;
 
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -12,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @DisplayName("Fixture syntax: Methods on JavaSpec instance")
 public class FixtureMethodSpecs {
   @TestFactory
-  DynamicNode makeSpecs() {
+  DynamicNode beforeEachSingle() {
     JavaSpec greeterSpecs = new JavaSpec();
     return greeterSpecs.describe(Greeter.class, () -> {
       AtomicReference<Greeter> subject = new AtomicReference<>();
@@ -28,6 +31,33 @@ public class FixtureMethodSpecs {
 
       greeterSpecs.it("greets a person by name", () -> {
         assertEquals("Hello George!", subject.get().makeGreeting("George"));
+      });
+    });
+  }
+
+  @TestFactory
+  DynamicNode beforeEachMultiple() {
+    JavaSpec specs = new JavaSpec();
+    return specs.describe(List.class, () -> {
+      AtomicReference<List<String>> subject = new AtomicReference<>();
+
+      specs.beforeEach(() -> {
+        //TODO KDK: Work here to get this beforeEach called in the it two levels below
+        System.out.println("beforeEach describe/List");
+        subject.set(new LinkedList<>());
+      });
+
+      specs.context("when the list has 1 or more elements", () -> {
+        specs.beforeEach(() -> {
+          System.out.println("beforeEach context/1+");
+          subject.get().add("existing");
+        });
+
+        specs.it("appends to the tail", () -> {
+          System.out.println("it/appends");
+          subject.get().add("appended");
+          assertEquals(Arrays.asList("existing", "appended"), subject.get());
+        });
       });
     });
   }

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/FixtureMethodSpecs.java
@@ -18,11 +18,18 @@ public class FixtureMethodSpecs {
       AtomicReference<Greeter> subject = new AtomicReference<>();
 
       greeterSpecs.beforeEach(() -> {
+        System.out.println("beforeEach");
         subject.set(new Greeter());
       });
 
       greeterSpecs.it("Greets the world", () -> {
+        System.out.println("it makeGreeting/0");
         assertEquals("Hello world!", subject.get().makeGreeting());
+      });
+
+      greeterSpecs.it("Greets a person by name", () -> {
+        System.out.println("it makeGreeting/1");
+        assertEquals("Hello George!", subject.get().makeGreeting("George"));
       });
     });
   }

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/JavaSpec.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/JavaSpec.java
@@ -11,12 +11,14 @@ import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-final class JavaSpec {
+final class JavaSpec<S> {
   private final Deque<DynamicNodeList> containers = new ArrayDeque<>();
+  private Supplier<S> subjectSupplier;
 
   public JavaSpec() {
     //Push a null object onto the bottom of the stack, so there's always a parent list to add nodes to.
@@ -70,6 +72,15 @@ final class JavaSpec {
 
     addToCurrentContainer(test);
     return test;
+  }
+
+  public S subject() {
+    return this.subjectSupplier.get();
+  }
+
+  //Future work: Support or reject subject overrides in nested blocks
+  public void subject(Supplier<S> supplier) {
+    this.subjectSupplier = supplier;
   }
 
   private void addToCurrentContainer(DynamicNode testOrContainer) {

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/JavaSpec.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/JavaSpec.java
@@ -5,8 +5,13 @@ import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
 import java.util.Stack;
+import java.util.stream.Collectors;
 
 final class JavaSpec {
   private final Stack<DynamicNodeList> containers = new Stack<>();
@@ -85,6 +90,27 @@ final class JavaSpec {
       DynamicTest test = DynamicTest.dynamicTest(behavior, () -> {
         if(this.arrange != null) {
           this.arrange.execute();
+        }
+
+        verification.execute();
+      });
+
+      add(test);
+      return test;
+    }
+
+    public DynamicTest addTestMultipleFixtures(String behavior, Executable verification) {
+      //TODO KDK: Convert the stack into a deque, inserting at the tail and iterating head->tail for setup (tail->head for teardown)
+      Deque<DynamicNodeList> containers = new ArrayDeque<>();
+      List<Executable> arrangements = containers.stream()
+        .map(x -> x.arrange)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+
+      //Future work: Allow multiple beforeEach in a single container?
+      DynamicTest test = DynamicTest.dynamicTest(behavior, () -> {
+        for(Executable arrange : arrangements) {
+          arrange.execute();
         }
 
         verification.execute();

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/JavaSpec.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/JavaSpec.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 final class JavaSpec<S> {
   private final Deque<DynamicNodeList> containers = new ArrayDeque<>();
   private Supplier<S> subjectSupplier;
+  private S memoizedSubject;
 
   public JavaSpec() {
     //Push a null object onto the bottom of the stack, so there's always a parent list to add nodes to.
@@ -75,7 +76,11 @@ final class JavaSpec<S> {
   }
 
   public S subject() {
-    return this.subjectSupplier.get();
+    if(this.memoizedSubject == null) {
+      this.memoizedSubject = this.subjectSupplier.get();
+    }
+
+    return this.memoizedSubject;
   }
 
   //Future work: Support or reject subject overrides in nested blocks

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/JavaSpec.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/JavaSpec.java
@@ -18,7 +18,7 @@ final class JavaSpec {
   }
 
   public void beforeEach(Executable arrange) {
-    containers.peek().pushBeforeEach(arrange);
+    containers.peek().setBeforeEach(arrange);
   }
 
   public void context(String condition, ContextBlock block) {
@@ -76,7 +76,7 @@ final class JavaSpec {
     //TODO KDK: Manage a queue of fixture lambdas, across all containers in the tree
     private Executable arrange;
 
-    public void pushBeforeEach(Executable arrange) {
+    public void setBeforeEach(Executable arrange) {
       this.arrange = arrange;
     }
 

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/JavaSpec.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/JavaSpec.java
@@ -22,10 +22,12 @@ final class JavaSpec {
     containers.addLast(new RootNodeList());
   }
 
+  //Positive: Supports any kind of code, that needs to run after each spec.
   public void afterEach(Executable clean) {
     containers.peekLast().setAfterEach(clean);
   }
 
+  //Positive: Supports any kind of code, that needs to run before each spec.
   public void beforeEach(Executable arrange) {
     containers.peekLast().setBeforeEach(arrange);
   }
@@ -43,6 +45,7 @@ final class JavaSpec {
   }
 
   public DynamicTest it(String behavior, Executable verification) {
+    //Positive: The algorithm for collecting fixture lambdas is straightforward enough, using a Deque.
     List<Executable> arrangements = containers.stream()
       .map(x -> x.arrange)
       .filter(Objects::nonNull)
@@ -110,6 +113,10 @@ final class JavaSpec {
           arrange.execute();
         }
 
+        //Unknown: Should a failed cleanup cause the spec to fail, even if all the assertions passed?
+        // I tend to think so, but it would be nice if the impact were clarified.
+        // Future work: What if AssertionErrors thrown from afterEach lambdas caused the spec to fail
+        // (sometimes they have odd assertions in them, too), but other failures caused a softer kind of failure?
         verification.execute();
         for(Executable cleanup : cleaners) {
           cleanup.execute();

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/JavaSpec.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/JavaSpec.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 final class JavaSpec {
   private final Deque<DynamicNodeList> containers = new ArrayDeque<>();
 
@@ -60,6 +62,16 @@ final class JavaSpec {
     return containers.peekLast().addTest(behavior, arrangements, verification, cleaners);
   }
 
+  public DynamicNode pending(String pendingBehavior) {
+    DynamicTest test = makeSkippedTest(
+      pendingBehavior,
+      String.format("Pending: %s.  This is not a failed assumption in the spec; it's just how JavaSpec skips a pending a spec.", pendingBehavior)
+    );
+
+    addToCurrentContainer(test);
+    return test;
+  }
+
   private void addToCurrentContainer(DynamicNode testOrContainer) {
     containers.peekLast().add(testOrContainer);
   }
@@ -74,6 +86,14 @@ final class JavaSpec {
     DynamicContainer childContainer = DynamicContainer.dynamicContainer(whatOrWhen, childNodes);
     addToCurrentContainer(childContainer);
     return childContainer;
+  }
+
+  private static DynamicTest makeSkippedTest(String intendedBehavior, String explanation) {
+    return DynamicTest.dynamicTest(intendedBehavior, () -> {
+      //Negative: It shows a misleading and distracting stack trace, due to the unmet assumption.
+      //Source: https://github.com/junit-team/junit5/issues/1439
+      assumeTrue(false, explanation);
+    });
   }
 
   @FunctionalInterface

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/JavaSpec.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/JavaSpec.java
@@ -73,7 +73,7 @@ final class JavaSpec {
   }
 
   private static class DynamicNodeList extends LinkedList<DynamicNode> {
-    //TODO KDK: Manage a stack of fixture lambdas, across all containers in the tree
+    //TODO KDK: Manage a queue of fixture lambdas, across all containers in the tree
     private Executable arrange;
 
     public void pushBeforeEach(Executable arrange) {
@@ -81,7 +81,7 @@ final class JavaSpec {
     }
 
     public DynamicTest addTest(String behavior, Executable verification) {
-      //TODO KDK: Handle multiple fixture lambdas, at each level in the container?
+      //Future work: Allow multiple beforeEach in a single container?
       DynamicTest test = DynamicTest.dynamicTest(behavior, () -> {
         if(this.arrange != null) {
           this.arrange.execute();

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/Minimax.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/Minimax.java
@@ -1,0 +1,56 @@
+package info.javaspec.jupiter.syntax.fixture;
+
+import java.util.Collection;
+
+final class Minimax {
+  private final String maximizerPlayer;
+  private final String minimizerPlayer;
+
+  public Minimax(String maximizerPlayer, String minimizerPlayer) {
+    this.maximizerPlayer = maximizerPlayer;
+    this.minimizerPlayer = minimizerPlayer;
+  }
+
+  public int score(GameState game, String player) {
+    if(this.maximizerPlayer.equals(game.findWinner())) {
+      return +1;
+    } else if(this.minimizerPlayer.equals(game.findWinner())) {
+      return -1;
+    } else if(game.isOver()) {
+      return 0;
+    }
+
+    if(this.maximizerPlayer.equals(player)) {
+      int bestScore = -100;
+      for(String nextMove : game.availableMoves()) {
+        GameState nextGame = game.move(nextMove);
+        int nextScore = score(nextGame, this.minimizerPlayer);
+        if(nextScore > bestScore) {
+          bestScore = nextScore;
+        }
+      }
+
+      return bestScore;
+    } else if(this.minimizerPlayer.equals(player)) {
+      int bestScore = +100;
+      for(String nextMove : game.availableMoves()) {
+        GameState nextGame = game.move(nextMove);
+        int nextScore = score(nextGame, this.maximizerPlayer);
+        if(nextScore < bestScore) {
+          bestScore = nextScore;
+        }
+      }
+
+      return bestScore;
+    }
+
+    return 9999;
+  }
+
+  interface GameState {
+    Collection<String> availableMoves();
+    String findWinner();
+    boolean isOver();
+    GameState move(String move);
+  }
+}

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/MinimaxSpecs.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/MinimaxSpecs.java
@@ -1,20 +1,129 @@
 package info.javaspec.jupiter.syntax.fixture;
 
+import info.javaspec.jupiter.syntax.fixture.Minimax.GameState;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.TestFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DisplayName("Fixture syntax: Minimax")
 class MinimaxSpecs {
   @TestFactory
   DynamicNode specs() {
-    JavaSpec spec = new JavaSpec();
+    JavaSpec<Minimax> spec = new JavaSpec<>();
     return spec.describe(Minimax.class, () -> {
-      spec.pending("exists");
+      spec.describe("score", () -> {
+        String max = "Max";
+        String min = "Min";
+        spec.subject(() -> new Minimax(max, min));
+
+        spec.context("given a game that is already over", () -> {
+          spec.it("scores a game ending in a draw as 0", () -> {
+            GameWithKnownStates game = new GameWithKnownStates(true);
+            assertEquals(0, spec.subject().score(game, max));
+          });
+
+          spec.it("scores a game won by the maximizer as +1", () -> {
+            GameWithKnownStates game = new GameWithKnownStates(true, max);
+            assertEquals(+1, spec.subject().score(game, max));
+          });
+
+          spec.it("scores a game won by the minimizer as -1", () -> {
+            GameWithKnownStates game = new GameWithKnownStates(true, min);
+            assertEquals(-1, spec.subject().score(game, max));
+          });
+        });
+
+        spec.context("given a game with 1 move left", () -> {
+          spec.it("the maximizer picks the move with the highest score", () -> {
+            GameWithKnownStates game = new GameWithKnownStates(false);
+            game.addKnownState("ThenDraw", new GameWithKnownStates(true));
+            game.addKnownState("ThenMaxWins", new GameWithKnownStates(true, max));
+            assertEquals(+1, spec.subject().score(game, max));
+          });
+
+          spec.it("the minimizer picks the move with the lowest score", () -> {
+            GameWithKnownStates game = new GameWithKnownStates(false);
+            game.addKnownState("ThenDraw", new GameWithKnownStates(true));
+            game.addKnownState("ThenMaxLoses", new GameWithKnownStates(true, min));
+            assertEquals(-1, spec.subject().score(game, min));
+          });
+        });
+
+        spec.context("given a game that has 2 or more moves left", () -> {
+          AtomicReference<GameWithKnownStates> game = new AtomicReference<>();
+
+          spec.beforeEach(() -> {
+            GameWithKnownStates theGame = new GameWithKnownStates(false);
+            GameWithKnownStates leftTree = new GameWithKnownStates(false);
+            theGame.addKnownState("Left", leftTree);
+            leftTree.addKnownState("ThenDraw", new GameWithKnownStates(true));
+            leftTree.addKnownState("ThenMaxWins", new GameWithKnownStates(true, max));
+
+            GameWithKnownStates rightTree = new GameWithKnownStates(false);
+            theGame.addKnownState("Right", rightTree);
+            rightTree.addKnownState("ThenDraw", new GameWithKnownStates(true));
+            rightTree.addKnownState("ThenMaxLoses", new GameWithKnownStates(true, min));
+
+            game.set(theGame);
+          });
+
+          spec.it("the maximizer assumes that the minimizer will pick the lowest score", () -> {
+            assertEquals(0, spec.subject().score(game.get(), max));
+          });
+
+          spec.it("the minimizer assumes that the maximizer will pick the highest score", () -> {
+            assertEquals(0, spec.subject().score(game.get(), min));
+          });
+        });
+      });
     });
   }
 
-  private static final class Minimax {
-    
+  private static final class GameWithKnownStates implements GameState {
+    private final boolean isOver;
+    private final String winner;
+    private final Map<String, GameWithKnownStates> nextGames = new LinkedHashMap<>();
+
+    public GameWithKnownStates(boolean isOver) {
+      this.isOver = isOver;
+      this.winner = null;
+    }
+
+    public GameWithKnownStates(boolean isOver, String winner) {
+      this.isOver = isOver;
+      this.winner = winner;
+    }
+
+    public void addKnownState(String nextMove, GameWithKnownStates nextGame) {
+      this.nextGames.put(nextMove, nextGame);
+    }
+
+    @Override
+    public Collection<String> availableMoves() {
+      return new ArrayList<>(this.nextGames.keySet());
+    }
+
+    @Override
+    public String findWinner() {
+      return this.winner;
+    }
+
+    @Override
+    public boolean isOver() {
+      return this.isOver;
+    }
+
+    @Override
+    public GameState move(String move) {
+      return this.nextGames.get(move);
+    }
   }
 }

--- a/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/MinimaxSpecs.java
+++ b/prototypes/javaspec-jupiter/src/test/java/info/javaspec/jupiter/syntax/fixture/MinimaxSpecs.java
@@ -1,0 +1,20 @@
+package info.javaspec.jupiter.syntax.fixture;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.TestFactory;
+
+@DisplayName("Fixture syntax: Minimax")
+class MinimaxSpecs {
+  @TestFactory
+  DynamicNode specs() {
+    JavaSpec spec = new JavaSpec();
+    return spec.describe(Minimax.class, () -> {
+      spec.pending("exists");
+    });
+  }
+
+  private static final class Minimax {
+    
+  }
+}


### PR DESCRIPTION
## What's Changing

Added a prototype implementation of `JavaSpec` that adds `#beforeEach` and `#afterEach` for DRY setup and teardown, respectively.

## Example

```java
@TestFactory
DynamicNode beforeEachExample() {
  JavaSpec<List<String>> specs = new JavaSpec<>();
  return specs.describe(List.class, () -> {
    specs.subject(() -> new LinkedList<>());

    specs.context("when the list has 1 or more elements", () -> {
      specs.beforeEach(() -> { //Added
        specs.subject().add("existing");
      });

      specs.it("appends to the tail", () -> {
        List<String> subject = specs.subject();
        subject.add("appended");
        assertEquals(Arrays.asList("existing", "appended"), subject);
      });
    });
  });
}
```