### PR TITLE
Update TravisCI to build prototypes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: java
+jdk: openjdk11
 
 before_install: cd prototypes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,3 @@
-#TODO KDK: Switch to one of the standard Java images and run gradle for prototypes
+language: java
 
-dist: trusty
-language: generic
-
-before_install: cd lambdas-and-strings
-
-install:
-- bundle --version
-- rake --version
-- bundle install
-- ./gradlew assemble --console=plain --stacktrace
-
-script: rake
+before_install: cd prototypes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+#TODO KDK: Switch to one of the standard Java images and run gradle for prototypes
+
 dist: trusty
 language: generic
 


### PR DESCRIPTION
`lambdas-and-strings` as a standalone CLI app isn't planned for release right now, and its TravisCI build takes a long time because it has to fire up a general VM and install Java+Ruby.  Switching the build over to just `prototypes`.