### PR TITLE
Eat that dog food v1

### DIFF
--- a/prototypes/javaspec-client/build.gradle
+++ b/prototypes/javaspec-client/build.gradle
@@ -9,6 +9,7 @@ version '0.0.1'
 
 dependencies {
   testImplementation project(':javaspec-api')
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
   testImplementation 'org.junit.platform:junit-platform-commons:1.8.1'
 
   testRuntimeOnly project(':javaspec-engine')

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/GreeterSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/GreeterSpecs.java
@@ -6,7 +6,8 @@ import org.junit.platform.commons.annotation.Testable;
 
 //Specs that exercise JavaSpec.
 //Run in IntelliJ or with ./gradlew :javaspec-client:test.
-//Adding this makes the run icon appear in IntelliJ, to run this spec individually.  Even without this, specs run just fine in IntelliJ if you select a package or source set and say "Run Tests".
+//Adding @Testable shows the run icon in IntelliJ, to run this spec by itself.
+//Without @Testable, you can still pick "Run Tests" on a package/directory.
 @Testable
 public class GreeterSpecs implements SpecClass {
   private static int _numTimesRun = 0;

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -4,17 +4,19 @@ import info.javaspec.api.JavaSpec;
 import info.javaspec.api.SpecClass;
 import org.junit.platform.commons.annotation.Testable;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 public class MinimaxSpecs implements SpecClass {
   public void declareSpecs(JavaSpec javaspec) {
     javaspec.it("scores a game ending in a draw as 0", () -> {
       Minimax subject = new Minimax();
-      subject.score();
+      assertEquals(0, subject.score());
     });
   }
 
   public static class Minimax {
     public int score() {
-      return 0;
+      return 9999;
     }
   }
 }

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -45,6 +45,23 @@ public class MinimaxSpecs implements SpecClass {
       game.addKnownState("ThenMinWins", GameWithKnownState.wonBy("Min"));
       assertEquals(-1, subject.score(game, "Min"));
     });
+
+    //TODO KDK: Just realized it's only running the last-declared spec
+    javaspec.it("given a game that will end in 2 or more moves, the maximizer assumes the minimizer will pick the lowest score", () -> {
+      GameWithKnownState game = GameWithKnownState.stillGoing();
+      GameWithKnownState leftTree = GameWithKnownState.stillGoing();
+      game.addKnownState("LeftTree", leftTree);
+      leftTree.addKnownState("AndDraw", GameWithKnownState.draw());
+      leftTree.addKnownState("AndMaxWins", GameWithKnownState.wonBy("Max"));
+
+      GameWithKnownState rightTree = GameWithKnownState.stillGoing();
+      game.addKnownState("RightTree", rightTree);
+      rightTree.addKnownState("AndDraw", GameWithKnownState.draw());
+      rightTree.addKnownState("AndMaxLoses", GameWithKnownState.wonBy("Min"));
+
+      Minimax subject = new Minimax("Max", "Min");
+      assertEquals(0, subject.score(game, "Max"));
+    });
   }
 
   public static class Minimax {
@@ -80,7 +97,7 @@ public class MinimaxSpecs implements SpecClass {
         int maxScore = -999;
         for(String nextMove : game.nextMoves()) {
           GameState nextGame = game.nextState(nextMove);
-          int score = score(nextGame, "Max");
+          int score = score(nextGame, this.minimizer);
           if(score > maxScore) {
             maxScore = score;
           }

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -10,13 +10,34 @@ public class MinimaxSpecs implements SpecClass {
   public void declareSpecs(JavaSpec javaspec) {
     javaspec.it("scores a game ending in a draw as 0", () -> {
       Minimax subject = new Minimax();
-      assertEquals(0, subject.score());
+      GameState game = new GameWithKnownState(true);
+      assertEquals(0, subject.score(game));
     });
   }
 
   public static class Minimax {
-    public int score() {
+    public int score(GameState game) {
+      if(game.isOver()) {
+        return 0;
+      }
+
       return 9999;
     }
+  }
+
+  public static class GameWithKnownState implements GameState {
+    private final boolean isOver;
+
+    public GameWithKnownState(boolean isOver) {
+      this.isOver = isOver;
+    }
+
+    public boolean isOver() {
+      return this.isOver;
+    }
+  }
+
+  public interface GameState {
+    boolean isOver();
   }
 }

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -1,5 +1,9 @@
 package info.javaspec.client;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import info.javaspec.api.JavaSpec;
 import info.javaspec.api.SpecClass;
 import org.junit.platform.commons.annotation.Testable;
@@ -11,23 +15,27 @@ public class MinimaxSpecs implements SpecClass {
     javaspec.it("scores a game ending in a draw as 0", () -> {
       Minimax subject = new Minimax("Max", "Min");
       GameState game = GameWithKnownState.draw();
-      assertEquals(0, subject.score(game));
+      assertEquals(0, subject.score(game, "Max"));
     });
 
     javaspec.it("scores a game won by the maximizer as +1", () -> {
       Minimax subject = new Minimax("Max", "Min");
       GameState game = GameWithKnownState.wonBy("Max");
-      assertEquals(+1, subject.score(game));
+      assertEquals(+1, subject.score(game, "Max"));
     });
 
     javaspec.it("scores a game won by the minimizer as -1", () -> {
       Minimax subject = new Minimax("Max", "Min");
       GameState game = GameWithKnownState.wonBy("Min");
-      assertEquals(-1, subject.score(game));
+      assertEquals(-1, subject.score(game, "Max"));
     });
 
-    javaspec.it("scores possible next states, from the maximizer's point of view", () -> {
-      throw new UnsupportedOperationException("Work here");
+    javaspec.it("given a game that will end in the next move, the maximizer picks the move with the highest score", () -> {
+      Minimax subject = new Minimax("Max", "Min");
+      GameWithKnownState game = GameWithKnownState.stillGoing();
+      game.addKnownState("ThenDraw", GameWithKnownState.draw());
+      game.addKnownState("ThenMaxWins", GameWithKnownState.wonBy("Max"));
+      assertEquals(+1, subject.score(game, "Max"));
     });
   }
 
@@ -40,7 +48,7 @@ public class MinimaxSpecs implements SpecClass {
       this.minimizer = minimizer;
     }
 
-    public int score(GameState game) {
+    public int score(GameState game, String player) {
       if(game.hasWon(this.maximizer)) {
         return +1;
       } else if(game.hasWon(this.minimizer)) {
@@ -49,16 +57,30 @@ public class MinimaxSpecs implements SpecClass {
         return 0;
       }
 
-      return 9999;
+      int maxScore = -999;
+      for(String nextMove : game.nextMoves()) {
+        GameState nextGame = game.nextState(nextMove);
+        int score = score(nextGame, "Max");
+        if(score > maxScore) {
+          maxScore = score;
+        }
+      }
+
+      return maxScore;
     }
   }
 
   public static class GameWithKnownState implements GameState {
     private final boolean isOver;
     private final String winner;
+    private final Map<String, GameState> nextMoves;
 
     public static GameWithKnownState draw() {
       return new GameWithKnownState(true, null);
+    }
+
+    public static GameWithKnownState stillGoing() {
+      return new GameWithKnownState(false, null);
     }
 
     public static GameWithKnownState wonBy(String winner) {
@@ -68,6 +90,11 @@ public class MinimaxSpecs implements SpecClass {
     private GameWithKnownState(boolean isOver, String winner) {
       this.isOver = isOver;
       this.winner = winner;
+      this.nextMoves = new LinkedHashMap<String, GameState>();
+    }
+
+    public void addKnownState(String move, GameState state) {
+      this.nextMoves.put(move, state);
     }
 
     public boolean hasWon(String player) {
@@ -77,10 +104,20 @@ public class MinimaxSpecs implements SpecClass {
     public boolean isOver() {
       return this.isOver;
     }
+
+    public List<String> nextMoves() {
+      return new ArrayList<>(this.nextMoves.keySet());
+    }
+
+    public GameState nextState(String move) {
+      return this.nextMoves.get(move);
+    }
   }
 
   public interface GameState {
     boolean hasWon(String player);
     boolean isOver();
+    List<String> nextMoves();
+    GameState nextState(String move);
   }
 }

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -61,6 +61,22 @@ public class MinimaxSpecs implements SpecClass {
       Minimax subject = new Minimax("Max", "Min");
       assertEquals(0, subject.score(game, "Max"));
     });
+
+    javaspec.it("given a game that will end in 2 or more moves, the minimizer assumes the maximizer will pick the highest score", () -> {
+      GameWithKnownState game = GameWithKnownState.stillGoing();
+      GameWithKnownState leftTree = GameWithKnownState.stillGoing();
+      game.addKnownState("LeftTree", leftTree);
+      leftTree.addKnownState("AndDraw", GameWithKnownState.draw());
+      leftTree.addKnownState("AndMaxWins", GameWithKnownState.wonBy("Max"));
+
+      GameWithKnownState rightTree = GameWithKnownState.stillGoing();
+      game.addKnownState("RightTree", rightTree);
+      rightTree.addKnownState("AndDraw", GameWithKnownState.draw());
+      rightTree.addKnownState("AndMaxLoses", GameWithKnownState.wonBy("Min"));
+
+      Minimax subject = new Minimax("Max", "Min");
+      assertEquals(0, subject.score(game, "Min"));
+    });
   }
 
   public static class Minimax {
@@ -85,7 +101,7 @@ public class MinimaxSpecs implements SpecClass {
         int minScore = +999;
         for(String nextMove : game.nextMoves()) {
           GameState nextGame = game.nextState(nextMove);
-          int score = score(nextGame, "Min");
+          int score = score(nextGame, this.maximizer);
           if(score < minScore) {
             minScore = score;
           }

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -9,21 +9,27 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MinimaxSpecs implements SpecClass {
   public void declareSpecs(JavaSpec javaspec) {
     javaspec.it("scores a game ending in a draw as 0", () -> {
-      Minimax subject = new Minimax();
+      Minimax subject = new Minimax("Max");
       GameState game = GameWithKnownState.draw();
       assertEquals(0, subject.score(game));
     });
 
     javaspec.it("scores a game won by the maximizer as +1", () -> {
-      Minimax subject = new Minimax();
+      Minimax subject = new Minimax("Max");
       GameState game = GameWithKnownState.wonBy("Max");
       assertEquals(1, subject.score(game));
     });
   }
 
   public static class Minimax {
+    private final String maximizer;
+
+    public Minimax(String maximizer) {
+      this.maximizer = maximizer;
+    }
+
     public int score(GameState game) {
-      if(game.hasWon("Max")) {
+      if(game.hasWon(this.maximizer)) {
         return +1;
       } else if(game.isOver()) {
         return 0;

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -47,22 +47,19 @@ public class MinimaxSpecs implements SpecClass {
     });
 
     javaspec.it("given a game that will end in 2 or more moves, the maximizer assumes the minimizer will pick the lowest score", () -> {
-      GameWithKnownState game = GameWithKnownState.stillGoing();
-      GameWithKnownState leftTree = GameWithKnownState.stillGoing();
-      game.addKnownState("LeftTree", leftTree);
-      leftTree.addKnownState("AndDraw", GameWithKnownState.draw());
-      leftTree.addKnownState("AndMaxWins", GameWithKnownState.wonBy("Max"));
-
-      GameWithKnownState rightTree = GameWithKnownState.stillGoing();
-      game.addKnownState("RightTree", rightTree);
-      rightTree.addKnownState("AndDraw", GameWithKnownState.draw());
-      rightTree.addKnownState("AndMaxLoses", GameWithKnownState.wonBy("Min"));
-
       Minimax subject = new Minimax("Max", "Min");
+      GameState game = gameWithTwoMovesLeft();
       assertEquals(0, subject.score(game, "Max"));
     });
 
     javaspec.it("given a game that will end in 2 or more moves, the minimizer assumes the maximizer will pick the highest score", () -> {
+      Minimax subject = new Minimax("Max", "Min");
+      GameState game = gameWithTwoMovesLeft();
+      assertEquals(0, subject.score(game, "Min"));
+    });
+  }
+
+  private static GameState gameWithTwoMovesLeft() {
       GameWithKnownState game = GameWithKnownState.stillGoing();
       GameWithKnownState leftTree = GameWithKnownState.stillGoing();
       game.addKnownState("LeftTree", leftTree);
@@ -74,9 +71,7 @@ public class MinimaxSpecs implements SpecClass {
       rightTree.addKnownState("AndDraw", GameWithKnownState.draw());
       rightTree.addKnownState("AndMaxLoses", GameWithKnownState.wonBy("Min"));
 
-      Minimax subject = new Minimax("Max", "Min");
-      assertEquals(0, subject.score(game, "Min"));
-    });
+      return game;
   }
 
   public static class Minimax {

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -9,28 +9,38 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MinimaxSpecs implements SpecClass {
   public void declareSpecs(JavaSpec javaspec) {
     javaspec.it("scores a game ending in a draw as 0", () -> {
-      Minimax subject = new Minimax("Max");
+      Minimax subject = new Minimax("Max", "Min");
       GameState game = GameWithKnownState.draw();
       assertEquals(0, subject.score(game));
     });
 
     javaspec.it("scores a game won by the maximizer as +1", () -> {
-      Minimax subject = new Minimax("Max");
+      Minimax subject = new Minimax("Max", "Min");
       GameState game = GameWithKnownState.wonBy("Max");
-      assertEquals(1, subject.score(game));
+      assertEquals(+1, subject.score(game));
+    });
+
+    javaspec.it("scores a game won by the minimizer as -1", () -> {
+      Minimax subject = new Minimax("Max", "Min");
+      GameState game = GameWithKnownState.wonBy("Min");
+      assertEquals(-1, subject.score(game));
     });
   }
 
   public static class Minimax {
     private final String maximizer;
+    private final String minimizer;
 
-    public Minimax(String maximizer) {
+    public Minimax(String maximizer, String minimizer) {
       this.maximizer = maximizer;
+      this.minimizer = minimizer;
     }
 
     public int score(GameState game) {
       if(game.hasWon(this.maximizer)) {
         return +1;
+      } else if(game.hasWon(this.minimizer)) {
+        return -1;
       } else if(game.isOver()) {
         return 0;
       }

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -37,6 +37,14 @@ public class MinimaxSpecs implements SpecClass {
       game.addKnownState("ThenMaxWins", GameWithKnownState.wonBy("Max"));
       assertEquals(+1, subject.score(game, "Max"));
     });
+
+    javaspec.it("given a game that will end in the next move, the minimizer picks the move with the lowest score", () -> {
+      Minimax subject = new Minimax("Max", "Min");
+      GameWithKnownState game = GameWithKnownState.stillGoing();
+      game.addKnownState("ThenDraw", GameWithKnownState.draw());
+      game.addKnownState("ThenMinWins", GameWithKnownState.wonBy("Min"));
+      assertEquals(-1, subject.score(game, "Min"));
+    });
   }
 
   public static class Minimax {
@@ -57,16 +65,29 @@ public class MinimaxSpecs implements SpecClass {
         return 0;
       }
 
-      int maxScore = -999;
-      for(String nextMove : game.nextMoves()) {
-        GameState nextGame = game.nextState(nextMove);
-        int score = score(nextGame, "Max");
-        if(score > maxScore) {
-          maxScore = score;
+      if(this.minimizer.equals(player)) {
+        int minScore = +999;
+        for(String nextMove : game.nextMoves()) {
+          GameState nextGame = game.nextState(nextMove);
+          int score = score(nextGame, "Min");
+          if(score < minScore) {
+            minScore = score;
+          }
         }
-      }
 
-      return maxScore;
+        return minScore;
+      } else {
+        int maxScore = -999;
+        for(String nextMove : game.nextMoves()) {
+          GameState nextGame = game.nextState(nextMove);
+          int score = score(nextGame, "Max");
+          if(score > maxScore) {
+            maxScore = score;
+          }
+        }
+
+        return maxScore;
+      }
     }
   }
 

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -25,6 +25,10 @@ public class MinimaxSpecs implements SpecClass {
       GameState game = GameWithKnownState.wonBy("Min");
       assertEquals(-1, subject.score(game));
     });
+
+    javaspec.it("scores possible next states, from the maximizer's point of view", () -> {
+      throw new UnsupportedOperationException("Work here");
+    });
   }
 
   public static class Minimax {

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -46,7 +46,6 @@ public class MinimaxSpecs implements SpecClass {
       assertEquals(-1, subject.score(game, "Min"));
     });
 
-    //TODO KDK: Just realized it's only running the last-declared spec
     javaspec.it("given a game that will end in 2 or more moves, the maximizer assumes the minimizer will pick the lowest score", () -> {
       GameWithKnownState game = GameWithKnownState.stillGoing();
       GameWithKnownState leftTree = GameWithKnownState.stillGoing();

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -10,14 +10,22 @@ public class MinimaxSpecs implements SpecClass {
   public void declareSpecs(JavaSpec javaspec) {
     javaspec.it("scores a game ending in a draw as 0", () -> {
       Minimax subject = new Minimax();
-      GameState game = new GameWithKnownState(true);
+      GameState game = GameWithKnownState.draw();
       assertEquals(0, subject.score(game));
+    });
+
+    javaspec.it("scores a game won by the maximizer as +1", () -> {
+      Minimax subject = new Minimax();
+      GameState game = GameWithKnownState.wonBy("Max");
+      assertEquals(1, subject.score(game));
     });
   }
 
   public static class Minimax {
     public int score(GameState game) {
-      if(game.isOver()) {
+      if(game.hasWon("Max")) {
+        return +1;
+      } else if(game.isOver()) {
         return 0;
       }
 
@@ -27,9 +35,23 @@ public class MinimaxSpecs implements SpecClass {
 
   public static class GameWithKnownState implements GameState {
     private final boolean isOver;
+    private final String winner;
 
-    public GameWithKnownState(boolean isOver) {
+    public static GameWithKnownState draw() {
+      return new GameWithKnownState(true, null);
+    }
+
+    public static GameWithKnownState wonBy(String winner) {
+      return new GameWithKnownState(true, winner);
+    }
+
+    private GameWithKnownState(boolean isOver, String winner) {
       this.isOver = isOver;
+      this.winner = winner;
+    }
+
+    public boolean hasWon(String player) {
+      return player.equals(this.winner);
     }
 
     public boolean isOver() {
@@ -38,6 +60,7 @@ public class MinimaxSpecs implements SpecClass {
   }
 
   public interface GameState {
+    boolean hasWon(String player);
     boolean isOver();
   }
 }

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -1,0 +1,20 @@
+package info.javaspec.client;
+
+import info.javaspec.api.JavaSpec;
+import info.javaspec.api.SpecClass;
+import org.junit.platform.commons.annotation.Testable;
+
+public class MinimaxSpecs implements SpecClass {
+  public void declareSpecs(JavaSpec javaspec) {
+    javaspec.it("scores a game ending in a draw as 0", () -> {
+      Minimax subject = new Minimax();
+      subject.score();
+    });
+  }
+
+  public static class Minimax {
+    public int score() {
+      return 0;
+    }
+  }
+}

--- a/prototypes/javaspec-engine/build.gradle
+++ b/prototypes/javaspec-engine/build.gradle
@@ -1,6 +1,7 @@
 //JUnit TestEngine that is discovered at runtime and runs specs under JUnit Jupiter
 plugins {
   id 'java-library'
+  id 'com.adarshr.test-logger' version '3.0.0'
 }
 
 group 'info.javaspec'
@@ -9,6 +10,8 @@ version '0.0.1'
 dependencies {
   implementation project(':javaspec-api')
   implementation 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+
+  testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
 }
 
 repositories {
@@ -16,5 +19,13 @@ repositories {
 }
 
 test {
-  useJUnitPlatform()
+  useJUnitPlatform {
+    //Run with the basic Jupiter engine, not the new thing we're building
+    excludeEngines 'javaspec-engine'
+  }
+}
+
+//https://github.com/radarsh/gradle-test-logger-plugin
+testlogger {
+  theme 'mocha'
 }

--- a/prototypes/javaspec-engine/build.gradle
+++ b/prototypes/javaspec-engine/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   implementation 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 
   testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+  testImplementation 'org.junit.platform:junit-platform-testkit:1.8.1'
 }
 
 repositories {

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -17,6 +17,7 @@ public class JavaSpecEngine implements TestEngine {
     EngineDescriptor engineDescriptor = new EngineDescriptor(engineId, "JavaSpec");
     discoveryRequest.getSelectorsByType(ClassSelector.class).stream()
       .map(ClassSelector::getJavaClass)
+      .filter(selectedClass -> SpecClass.class.isAssignableFrom(selectedClass))
       .map(selectedClass -> (Class<SpecClass>) selectedClass)
       .map(specClass -> makeDeclaringInstance(specClass))
       .forEach(declaringInstance -> {

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -117,7 +117,11 @@ public class JavaSpecEngine implements TestEngine {
       spec.run();
     } else if (descriptor.isContainer()) {
       for (TestDescriptor child : descriptor.getChildren()) {
-        execute(child, listener);
+        try {
+          execute(child, listener);
+        } catch (AssertionError e) {
+          listener.executionFinished(child, TestExecutionResult.failed(e));
+        }
       }
     } else {
       //Throwing exceptions from here didn't seem to cause any warnings, error messages, or failures.

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -119,7 +119,7 @@ public class JavaSpecEngine implements TestEngine {
       for (TestDescriptor child : descriptor.getChildren()) {
         try {
           execute(child, listener);
-        } catch (AssertionError e) {
+        } catch (AssertionError|Exception e) {
           listener.executionFinished(child, TestExecutionResult.failed(e));
         }
       }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecForJupiter.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecForJupiter.java
@@ -1,5 +1,7 @@
 package info.javaspec.engine;
 
+import java.util.LinkedList;
+import java.util.List;
 import info.javaspec.api.JavaSpec;
 import info.javaspec.api.Verification;
 import org.junit.platform.engine.TestDescriptor;
@@ -10,7 +12,7 @@ import java.util.Optional;
 
 //A JavaSpec declaration that runs 1 or more specs on JUnit
 public class JavaSpecForJupiter extends AbstractTestDescriptor implements JavaSpec {
-  private JupiterSpec spec;
+  private final List<JupiterSpec> specs;
 
   public static JavaSpecForJupiter forSpecClass(UniqueId parentId, Class<?> specClass) {
     return new JavaSpecForJupiter(
@@ -21,6 +23,7 @@ public class JavaSpecForJupiter extends AbstractTestDescriptor implements JavaSp
 
   private JavaSpecForJupiter(UniqueId uniqueId, String displayName) {
     super(uniqueId, displayName);
+    this.specs = new LinkedList<>();
   }
 
   /* Jupiter */
@@ -32,14 +35,17 @@ public class JavaSpecForJupiter extends AbstractTestDescriptor implements JavaSp
 
   public void addDescriptorsTo(TestDescriptor parentDescriptor) {
     parentDescriptor.addChild(this);
-    Optional.ofNullable(this.spec)
-      .ifPresent(x -> x.addTestDescriptorTo(this));
+    this.specs.forEach(x -> x.addTestDescriptorTo(this));
   }
 
   /* JavaSpec syntax */
 
   @Override
   public void it(String behavior, Verification verification) {
-    this.spec = JupiterSpec.forBehavior(getUniqueId(), behavior, verification);
+    this.specs.add(JupiterSpec.forBehavior(
+      getUniqueId(),
+      behavior,
+      verification
+    ));
   }
 }

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/EmptySpecs.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/EmptySpecs.java
@@ -1,0 +1,4 @@
+package info.javaspec.engine;
+
+//An empty class that has no specs in it.  Guess how many tests it should run?
+public class EmptySpecs { /* empty */ }

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/EmptySpecs.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/EmptySpecs.java
@@ -1,4 +1,10 @@
 package info.javaspec.engine;
 
-//An empty class that has no specs in it.  Guess how many tests it should run?
-public class EmptySpecs { /* empty */ }
+import info.javaspec.api.JavaSpec;
+import info.javaspec.api.SpecClass;
+
+//An empty class that has no specs in it.
+public class EmptySpecs implements SpecClass {
+  @Override
+  public void declareSpecs(JavaSpec javaspec) { /* empty */ }
+}

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -1,27 +1,34 @@
 package info.javaspec.engine;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.EngineTestKit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.testkit.engine.EventConditions.*;
 
 @DisplayName("JavaSpecEngine")
 public class JavaSpecEngineTest {
   @Test
-  @DisplayName("loads EngineTestKit like a boss")
-  public void loadsEngineTestKit() throws Exception {
-    EngineTestKit.engine("javaspec-engine");
+  @DisplayName("runs a test container for the engine itself")
+  public void runsASpecForTheContainingClass() throws Exception {
+    EngineExecutionResults results = EngineTestKit.engine("javaspec-engine")
+      .selectors(selectClass(EmptySpecs.class))
+      .execute();
+
+    results.containerEvents().assertEventsMatchExactly(
+      event(engine(), started()),
+      event(engine(), finishedSuccessfully())
+    );
+
+    results.testEvents().assertEventsMatchExactly();
   }
 
   @Test
-  @DisplayName("complies with the Jupiter Core API for TestEngines")
-  public void compliesWithJupiterCore() throws Exception {
-    EngineTestKit.engine("javaspec-engine")
-      .selectors(selectClass(EmptySpecs.class))
-      .execute()
-      .containerEvents()
-      .assertStatistics(stats -> stats.started(0).finished(0));
+  @Disabled
+  @DisplayName("accepts spec classes that do not implement SpecClass")
+  public void acceptsAnyClassWithSpecsInIt() throws Exception {
   }
 }

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -1,13 +1,27 @@
 package info.javaspec.engine;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.testkit.engine.EngineTestKit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
+@DisplayName("JavaSpecEngine")
 public class JavaSpecEngineTest {
   @Test
-  public void sayHello() throws Exception {
-    String greeting = "Hello world!";
-    assertEquals("Hello world!", greeting);
+  @DisplayName("loads EngineTestKit like a boss")
+  public void loadsEngineTestKit() throws Exception {
+    EngineTestKit.engine("javaspec-engine");
+  }
+
+  @Test
+  @DisplayName("complies with the Jupiter Core API for TestEngines")
+  public void compliesWithJupiterCore() throws Exception {
+    EngineTestKit.engine("javaspec-engine")
+      .selectors(selectClass(EmptySpecs.class))
+      .execute()
+      .containerEvents()
+      .assertStatistics(stats -> stats.started(0).finished(0));
   }
 }

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -1,0 +1,13 @@
+package info.javaspec.engine;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JavaSpecEngineTest {
+  @Test
+  public void sayHello() throws Exception {
+    String greeting = "Hello world!";
+    assertEquals("Hello world!", greeting);
+  }
+}

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/OneFlatSpecs.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/OneFlatSpecs.java
@@ -1,0 +1,12 @@
+package info.javaspec.engine;
+
+import info.javaspec.api.JavaSpec;
+import info.javaspec.api.SpecClass;
+
+//Declares a single spec
+public class OneFlatSpecs implements SpecClass {
+  @Override
+  public void declareSpecs(JavaSpec javaspec) {
+    javaspec.it("works", () -> {});
+  }
+}


### PR DESCRIPTION
Use `javaspec-engine` to drive finding and fixing bugs in realistic workflows, while test-driving Minimax.

This includes several small changes that are loosely related:

* Including `jupiter-api` and using `@Testable`, for IDE integration.
* Introduce `EngineTestKit`, which can be useful for verifying more behavior on `javaspec-engine` when I'm ready for that step.
* Fixing some bugs and/or addressing show-stoppers in `javaspec-engine`:
  * Skip trying to discover specs in classes that do not implement `SpecClass`.
  * Catching exceptions when tests run and using them to fail the test, instead of crashing the engine
  * Run more than 1 spec in a `SpecClass`