### PR TITLE
Format prototype code

### DIFF
--- a/prototypes/.editorconfig
+++ b/prototypes/.editorconfig
@@ -1,8 +1,18 @@
 # EditorConfig is awesome: https://EditorConfig.org
 root = true
 
-[*.gradle]
+[*]
 end_of_line = lf
-indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.gradle]
+indent_style = tab
+
+[*.md]
+indent_size = 2
+indent_style = space
+
+[*.sh]
+indent_size = 2
+indent_style = space

--- a/prototypes/.editorconfig
+++ b/prototypes/.editorconfig
@@ -1,0 +1,8 @@
+# EditorConfig is awesome: https://EditorConfig.org
+root = true
+
+[*.gradle]
+end_of_line = lf
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/prototypes/.editorconfig
+++ b/prototypes/.editorconfig
@@ -9,6 +9,9 @@ trim_trailing_whitespace = true
 [*.gradle]
 indent_style = tab
 
+[*.java]
+indent_style = tab
+
 [*.md]
 indent_size = 2
 indent_style = space

--- a/prototypes/build.gradle
+++ b/prototypes/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'com.adarshr.test-logger' version '3.1.0' apply false
+	id 'com.diffplug.spotless' version '6.3.0' apply false
 }
 
 subprojects {
@@ -7,5 +8,13 @@ subprojects {
 
 	repositories {
 		mavenCentral()
+	}
+
+	//https://github.com/diffplug/spotless/tree/main/plugin-gradle#java
+	apply plugin: 'com.diffplug.spotless'
+	spotless {
+		java {
+			eclipse()
+		}
 	}
 }

--- a/prototypes/build.gradle
+++ b/prototypes/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+  id 'com.adarshr.test-logger' version '3.1.0' apply false
+}
+
+subprojects {
+  group 'info.javaspec'
+
+  repositories {
+    mavenCentral()
+  }
+}

--- a/prototypes/build.gradle
+++ b/prototypes/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-  id 'com.adarshr.test-logger' version '3.1.0' apply false
+	id 'com.adarshr.test-logger' version '3.1.0' apply false
 }
 
 subprojects {
-  group 'info.javaspec'
+	group 'info.javaspec'
 
-  repositories {
-    mavenCentral()
-  }
+	repositories {
+		mavenCentral()
+	}
 }

--- a/prototypes/build.gradle
+++ b/prototypes/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'com.adarshr.test-logger' version '3.1.0' apply false
-	id 'com.diffplug.spotless' version '6.3.0' apply false
+	id 'com.diffplug.spotless' version '6.3.0' apply false //https://github.com/diffplug/spotless/tree/main/plugin-gradle#java
 }
 
 subprojects {
@@ -8,13 +8,5 @@ subprojects {
 
 	repositories {
 		mavenCentral()
-	}
-
-	//https://github.com/diffplug/spotless/tree/main/plugin-gradle#java
-	apply plugin: 'com.diffplug.spotless'
-	spotless {
-		java {
-			eclipse()
-		}
 	}
 }

--- a/prototypes/javaspec-api/build.gradle
+++ b/prototypes/javaspec-api/build.gradle
@@ -1,9 +1,16 @@
 //Code that JavaSpec clients use to write (not run) their specs
 plugins {
 	id 'java-library'
+	id 'com.diffplug.spotless'
 }
 
 dependencies { }
+
+spotless {
+	java {
+		eclipse()
+	}
+}
 
 test {
 	useJUnitPlatform()

--- a/prototypes/javaspec-api/build.gradle
+++ b/prototypes/javaspec-api/build.gradle
@@ -1,12 +1,12 @@
 //Code that JavaSpec clients use to write (not run) their specs
 plugins {
-  id 'java-library'
+	id 'java-library'
 }
 
 dependencies { }
 
 test {
-  useJUnitPlatform()
+	useJUnitPlatform()
 }
 
 version '0.0.1'

--- a/prototypes/javaspec-api/build.gradle
+++ b/prototypes/javaspec-api/build.gradle
@@ -3,15 +3,10 @@ plugins {
   id 'java-library'
 }
 
-group 'info.javaspec'
-version '0.0.1'
-
 dependencies { }
-
-repositories {
-  mavenCentral()
-}
 
 test {
   useJUnitPlatform()
 }
+
+version '0.0.1'

--- a/prototypes/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
+++ b/prototypes/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
@@ -2,5 +2,5 @@ package info.javaspec.api;
 
 //Entrypoint for all syntax used to write specs in JavaSpec
 public interface JavaSpec {
-  void it(String behavior, Verification verification);
+	void it(String behavior, Verification verification);
 }

--- a/prototypes/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
+++ b/prototypes/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
@@ -2,5 +2,5 @@ package info.javaspec.api;
 
 //A class with specs in it
 public interface SpecClass {
-  void declareSpecs(JavaSpec javaspec);
+	void declareSpecs(JavaSpec javaspec);
 }

--- a/prototypes/javaspec-api/src/main/java/info/javaspec/api/Verification.java
+++ b/prototypes/javaspec-api/src/main/java/info/javaspec/api/Verification.java
@@ -3,5 +3,5 @@ package info.javaspec.api;
 //A procedure that verifies the behavior under test
 @FunctionalInterface
 public interface Verification {
-  void execute();
+	void execute();
 }

--- a/prototypes/javaspec-client/build.gradle
+++ b/prototypes/javaspec-client/build.gradle
@@ -1,11 +1,8 @@
 //Code that uses JavaSpec's API to write specs
 plugins {
   id 'java'
-  id 'com.adarshr.test-logger' version '3.1.0'
+  id 'com.adarshr.test-logger'
 }
-
-group 'info.javaspec'
-version '0.0.1'
 
 dependencies {
   testImplementation project(':javaspec-api')
@@ -15,10 +12,6 @@ dependencies {
 //  testRuntimeOnly project(':javaspec-engine-discovery-request-listener')
 //  testRuntimeOnly project(':jupiter-test-execution-listener')
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-}
-
-repositories {
-  mavenCentral()
 }
 
 //Suspected Gradle issue Gradle groups tests by 'default-package' and 'UnknownClass'.
@@ -40,3 +33,5 @@ testlogger {
   theme 'mocha-parallel' //Override at runtime with: -Dtestlogger.theme=plain-parallel
   showSimpleNames true
 }
+
+version '0.0.1'

--- a/prototypes/javaspec-client/build.gradle
+++ b/prototypes/javaspec-client/build.gradle
@@ -2,6 +2,7 @@
 plugins {
 	id 'java'
 	id 'com.adarshr.test-logger'
+	id 'com.diffplug.spotless'
 }
 
 dependencies {
@@ -12,6 +13,12 @@ dependencies {
 //  testRuntimeOnly project(':javaspec-engine-discovery-request-listener')
 //  testRuntimeOnly project(':jupiter-test-execution-listener')
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+}
+
+spotless {
+	java {
+		eclipse()
+	}
 }
 
 //Suspected Gradle issue Gradle groups tests by 'default-package' and 'UnknownClass'.

--- a/prototypes/javaspec-client/build.gradle
+++ b/prototypes/javaspec-client/build.gradle
@@ -1,37 +1,37 @@
 //Code that uses JavaSpec's API to write specs
 plugins {
-  id 'java'
-  id 'com.adarshr.test-logger'
+	id 'java'
+	id 'com.adarshr.test-logger'
 }
 
 dependencies {
-  testImplementation project(':javaspec-api')
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+	testImplementation project(':javaspec-api')
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
 
-  testRuntimeOnly project(':javaspec-engine')
+	testRuntimeOnly project(':javaspec-engine')
 //  testRuntimeOnly project(':javaspec-engine-discovery-request-listener')
 //  testRuntimeOnly project(':jupiter-test-execution-listener')
-  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
 //Suspected Gradle issue Gradle groups tests by 'default-package' and 'UnknownClass'.
 //Related Github issue: https://github.com/cucumber/cucumber-jvm/issues/2176
 test {
-  useJUnitPlatform {
-    //Jupiter will find this engine even if it's omitted, as long as it's on the classpath.
-    includeEngines 'javaspec-engine'
-  }
+	useJUnitPlatform {
+		//Jupiter will find this engine even if it's omitted, as long as it's on the classpath.
+		includeEngines 'javaspec-engine'
+	}
 
-  //Show all output: the specs themselves *and* the TestEngine
-  onOutput { _descriptor, TestOutputEvent engineEvent ->
-    logger.lifecycle(engineEvent.message.trim())
-  }
+	//Show all output: the specs themselves *and* the TestEngine
+	onOutput { _descriptor, TestOutputEvent engineEvent ->
+		logger.lifecycle(engineEvent.message.trim())
+	}
 }
 
 //https://github.com/radarsh/gradle-test-logger-plugin
 testlogger {
-  theme 'mocha-parallel' //Override at runtime with: -Dtestlogger.theme=plain-parallel
-  showSimpleNames true
+	theme 'mocha-parallel' //Override at runtime with: -Dtestlogger.theme=plain-parallel
+	showSimpleNames true
 }
 
 version '0.0.1'

--- a/prototypes/javaspec-client/src/main/java/info/javaspec/client/Greeter.java
+++ b/prototypes/javaspec-client/src/main/java/info/javaspec/client/Greeter.java
@@ -1,7 +1,7 @@
 package info.javaspec.client;
 
 public class Greeter {
-  public String greet() {
-    return "Hello world!";
-  }
+	public String greet() {
+		return "Hello world!";
+	}
 }

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/GreeterSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/GreeterSpecs.java
@@ -10,41 +10,36 @@ import org.junit.platform.commons.annotation.Testable;
 //Without @Testable, you can still pick "Run Tests" on a package/directory.
 @Testable
 public class GreeterSpecs implements SpecClass {
-  private static int _numTimesRun = 0;
+	private static int _numTimesRun = 0;
 
-  //Called via reflection
-  public static void assertRanOnce() {
-    assertEquals(1, _numTimesRun, "Expected GreeterSpecs to have been run once");
-  }
+	// Called via reflection
+	public static void assertRanOnce() {
+		assertEquals(1, _numTimesRun, "Expected GreeterSpecs to have been run once");
+	}
 
-  public static void incrementRunCount() {
-    _numTimesRun++;
-  }
+	public static void incrementRunCount() {
+		_numTimesRun++;
+	}
 
-  public void declareSpecs(JavaSpec javaspec) {
-    javaspec.it("greets the world", () -> {
-      incrementRunCount();
-      Greeter subject = new Greeter();
-      assertEquals("Hello world!", subject.greet());
-    });
-  }
+	public void declareSpecs(JavaSpec javaspec) {
+		javaspec.it("greets the world", () -> {
+			incrementRunCount();
+			Greeter subject = new Greeter();
+			assertEquals("Hello world!", subject.greet());
+		});
+	}
 
-  private static void assertEquals(int expected, int actual, String message) {
-    if(actual == expected)
-      return;
+	private static void assertEquals(int expected, int actual, String message) {
+		if (actual == expected)
+			return;
 
-    throw new AssertionError(String.format(
-      "%s: Expected <%s>, but was <%s>",
-      message,
-      expected,
-      actual
-    ));
-  }
+		throw new AssertionError(String.format("%s: Expected <%s>, but was <%s>", message, expected, actual));
+	}
 
-  private static void assertEquals(String expected, String actual) {
-    if(expected.equals(actual))
-      return;
+	private static void assertEquals(String expected, String actual) {
+		if (expected.equals(actual))
+			return;
 
-    throw new AssertionError(String.format("Expected <%s>, but was <%s>", expected, actual));
-  }
+		throw new AssertionError(String.format("Expected <%s>, but was <%s>", expected, actual));
+	}
 }

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -12,161 +12,163 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @Testable
 public class MinimaxSpecs implements SpecClass {
-  public void declareSpecs(JavaSpec javaspec) {
-    javaspec.it("scores a game ending in a draw as 0", () -> {
-      Minimax subject = new Minimax("Max", "Min");
-      GameState game = GameWithKnownState.draw();
-      assertEquals(0, subject.score(game, "Max"));
-    });
+	public void declareSpecs(JavaSpec javaspec) {
+		javaspec.it("scores a game ending in a draw as 0", () -> {
+			Minimax subject = new Minimax("Max", "Min");
+			GameState game = GameWithKnownState.draw();
+			assertEquals(0, subject.score(game, "Max"));
+		});
 
-    javaspec.it("scores a game won by the maximizer as +1", () -> {
-      Minimax subject = new Minimax("Max", "Min");
-      GameState game = GameWithKnownState.wonBy("Max");
-      assertEquals(+1, subject.score(game, "Max"));
-    });
+		javaspec.it("scores a game won by the maximizer as +1", () -> {
+			Minimax subject = new Minimax("Max", "Min");
+			GameState game = GameWithKnownState.wonBy("Max");
+			assertEquals(+1, subject.score(game, "Max"));
+		});
 
-    javaspec.it("scores a game won by the minimizer as -1", () -> {
-      Minimax subject = new Minimax("Max", "Min");
-      GameState game = GameWithKnownState.wonBy("Min");
-      assertEquals(-1, subject.score(game, "Max"));
-    });
+		javaspec.it("scores a game won by the minimizer as -1", () -> {
+			Minimax subject = new Minimax("Max", "Min");
+			GameState game = GameWithKnownState.wonBy("Min");
+			assertEquals(-1, subject.score(game, "Max"));
+		});
 
-    javaspec.it("given a game that will end in the next move, the maximizer picks the move with the highest score", () -> {
-      Minimax subject = new Minimax("Max", "Min");
-      GameWithKnownState game = GameWithKnownState.stillGoing();
-      game.addKnownState("ThenDraw", GameWithKnownState.draw());
-      game.addKnownState("ThenMaxWins", GameWithKnownState.wonBy("Max"));
-      assertEquals(+1, subject.score(game, "Max"));
-    });
+		javaspec.it("given a game ending in 1 move, the maximizer picks the move with the highest score", () -> {
+			Minimax subject = new Minimax("Max", "Min");
+			GameWithKnownState game = GameWithKnownState.stillGoing();
+			game.addKnownState("ThenDraw", GameWithKnownState.draw());
+			game.addKnownState("ThenMaxWins", GameWithKnownState.wonBy("Max"));
+			assertEquals(+1, subject.score(game, "Max"));
+		});
 
-    javaspec.it("given a game that will end in the next move, the minimizer picks the move with the lowest score", () -> {
-      Minimax subject = new Minimax("Max", "Min");
-      GameWithKnownState game = GameWithKnownState.stillGoing();
-      game.addKnownState("ThenDraw", GameWithKnownState.draw());
-      game.addKnownState("ThenMinWins", GameWithKnownState.wonBy("Min"));
-      assertEquals(-1, subject.score(game, "Min"));
-    });
+		javaspec.it("given a game ending in 1 move, the minimizer picks the move with the lowest score", () -> {
+			Minimax subject = new Minimax("Max", "Min");
+			GameWithKnownState game = GameWithKnownState.stillGoing();
+			game.addKnownState("ThenDraw", GameWithKnownState.draw());
+			game.addKnownState("ThenMinWins", GameWithKnownState.wonBy("Min"));
+			assertEquals(-1, subject.score(game, "Min"));
+		});
 
-    javaspec.it("given a game that will end in 2 or more moves, the maximizer assumes the minimizer will pick the lowest score", () -> {
-      Minimax subject = new Minimax("Max", "Min");
-      GameState game = gameWithTwoMovesLeft();
-      assertEquals(0, subject.score(game, "Max"));
-    });
+		javaspec.it("given a game ending in 2+ moves, the maximizer assumes the minimizer picks the lowest score",
+				() -> {
+					Minimax subject = new Minimax("Max", "Min");
+					GameState game = gameWithTwoMovesLeft();
+					assertEquals(0, subject.score(game, "Max"));
+				});
 
-    javaspec.it("given a game that will end in 2 or more moves, the minimizer assumes the maximizer will pick the highest score", () -> {
-      Minimax subject = new Minimax("Max", "Min");
-      GameState game = gameWithTwoMovesLeft();
-      assertEquals(0, subject.score(game, "Min"));
-    });
-  }
+		javaspec.it("given a game ending in 2+ moves, the minimizer assumes the maximizer picks the highest score",
+				() -> {
+					Minimax subject = new Minimax("Max", "Min");
+					GameState game = gameWithTwoMovesLeft();
+					assertEquals(0, subject.score(game, "Min"));
+				});
+	}
 
-  private static GameState gameWithTwoMovesLeft() {
-      GameWithKnownState game = GameWithKnownState.stillGoing();
-      GameWithKnownState leftTree = GameWithKnownState.stillGoing();
-      game.addKnownState("LeftTree", leftTree);
-      leftTree.addKnownState("AndDraw", GameWithKnownState.draw());
-      leftTree.addKnownState("AndMaxWins", GameWithKnownState.wonBy("Max"));
+	private static GameState gameWithTwoMovesLeft() {
+		GameWithKnownState game = GameWithKnownState.stillGoing();
+		GameWithKnownState leftTree = GameWithKnownState.stillGoing();
+		game.addKnownState("LeftTree", leftTree);
+		leftTree.addKnownState("AndDraw", GameWithKnownState.draw());
+		leftTree.addKnownState("AndMaxWins", GameWithKnownState.wonBy("Max"));
 
-      GameWithKnownState rightTree = GameWithKnownState.stillGoing();
-      game.addKnownState("RightTree", rightTree);
-      rightTree.addKnownState("AndDraw", GameWithKnownState.draw());
-      rightTree.addKnownState("AndMaxLoses", GameWithKnownState.wonBy("Min"));
+		GameWithKnownState rightTree = GameWithKnownState.stillGoing();
+		game.addKnownState("RightTree", rightTree);
+		rightTree.addKnownState("AndDraw", GameWithKnownState.draw());
+		rightTree.addKnownState("AndMaxLoses", GameWithKnownState.wonBy("Min"));
 
-      return game;
-  }
+		return game;
+	}
 
-  public static class Minimax {
-    private final String maximizer;
-    private final String minimizer;
+	public static class Minimax {
+		private final String maximizer;
+		private final String minimizer;
 
-    public Minimax(String maximizer, String minimizer) {
-      this.maximizer = maximizer;
-      this.minimizer = minimizer;
-    }
+		public Minimax(String maximizer, String minimizer) {
+			this.maximizer = maximizer;
+			this.minimizer = minimizer;
+		}
 
-    public int score(GameState game, String player) {
-      if(game.hasWon(this.maximizer)) {
-        return +1;
-      } else if(game.hasWon(this.minimizer)) {
-        return -1;
-      } else if(game.isOver()) {
-        return 0;
-      }
+		public int score(GameState game, String player) {
+			if (game.hasWon(this.maximizer)) {
+				return +1;
+			} else if (game.hasWon(this.minimizer)) {
+				return -1;
+			} else if (game.isOver()) {
+				return 0;
+			}
 
-      if(this.minimizer.equals(player)) {
-        int minScore = +999;
-        for(String nextMove : game.nextMoves()) {
-          GameState nextGame = game.nextState(nextMove);
-          int score = score(nextGame, this.maximizer);
-          if(score < minScore) {
-            minScore = score;
-          }
-        }
+			if (this.minimizer.equals(player)) {
+				int minScore = +999;
+				for (String nextMove : game.nextMoves()) {
+					GameState nextGame = game.nextState(nextMove);
+					int score = score(nextGame, this.maximizer);
+					if (score < minScore) {
+						minScore = score;
+					}
+				}
 
-        return minScore;
-      } else {
-        int maxScore = -999;
-        for(String nextMove : game.nextMoves()) {
-          GameState nextGame = game.nextState(nextMove);
-          int score = score(nextGame, this.minimizer);
-          if(score > maxScore) {
-            maxScore = score;
-          }
-        }
+				return minScore;
+			} else {
+				int maxScore = -999;
+				for (String nextMove : game.nextMoves()) {
+					GameState nextGame = game.nextState(nextMove);
+					int score = score(nextGame, this.minimizer);
+					if (score > maxScore) {
+						maxScore = score;
+					}
+				}
 
-        return maxScore;
-      }
-    }
-  }
+				return maxScore;
+			}
+		}
+	}
 
-  public static class GameWithKnownState implements GameState {
-    private final boolean isOver;
-    private final String winner;
-    private final Map<String, GameState> nextMoves;
+	public static class GameWithKnownState implements GameState {
+		private final boolean isOver;
+		private final String winner;
+		private final Map<String, GameState> nextMoves;
 
-    public static GameWithKnownState draw() {
-      return new GameWithKnownState(true, null);
-    }
+		public static GameWithKnownState draw() {
+			return new GameWithKnownState(true, null);
+		}
 
-    public static GameWithKnownState stillGoing() {
-      return new GameWithKnownState(false, null);
-    }
+		public static GameWithKnownState stillGoing() {
+			return new GameWithKnownState(false, null);
+		}
 
-    public static GameWithKnownState wonBy(String winner) {
-      return new GameWithKnownState(true, winner);
-    }
+		public static GameWithKnownState wonBy(String winner) {
+			return new GameWithKnownState(true, winner);
+		}
 
-    private GameWithKnownState(boolean isOver, String winner) {
-      this.isOver = isOver;
-      this.winner = winner;
-      this.nextMoves = new LinkedHashMap<String, GameState>();
-    }
+		private GameWithKnownState(boolean isOver, String winner) {
+			this.isOver = isOver;
+			this.winner = winner;
+			this.nextMoves = new LinkedHashMap<String, GameState>();
+		}
 
-    public void addKnownState(String move, GameState state) {
-      this.nextMoves.put(move, state);
-    }
+		public void addKnownState(String move, GameState state) {
+			this.nextMoves.put(move, state);
+		}
 
-    public boolean hasWon(String player) {
-      return player.equals(this.winner);
-    }
+		public boolean hasWon(String player) {
+			return player.equals(this.winner);
+		}
 
-    public boolean isOver() {
-      return this.isOver;
-    }
+		public boolean isOver() {
+			return this.isOver;
+		}
 
-    public List<String> nextMoves() {
-      return new ArrayList<>(this.nextMoves.keySet());
-    }
+		public List<String> nextMoves() {
+			return new ArrayList<>(this.nextMoves.keySet());
+		}
 
-    public GameState nextState(String move) {
-      return this.nextMoves.get(move);
-    }
-  }
+		public GameState nextState(String move) {
+			return this.nextMoves.get(move);
+		}
+	}
 
-  public interface GameState {
-    boolean hasWon(String player);
-    boolean isOver();
-    List<String> nextMoves();
-    GameState nextState(String move);
-  }
+	public interface GameState {
+		boolean hasWon(String player);
+		boolean isOver();
+		List<String> nextMoves();
+		GameState nextState(String move);
+	}
 }

--- a/prototypes/javaspec-client/src/test/java/info/javaspec/client/OtherSpecs.java
+++ b/prototypes/javaspec-client/src/test/java/info/javaspec/client/OtherSpecs.java
@@ -6,21 +6,17 @@ import org.junit.platform.commons.annotation.Testable;
 
 @Testable
 public class OtherSpecs implements SpecClass {
-  public void declareSpecs(JavaSpec javaspec) {
-    javaspec.it("answers the meaning of life", () -> {
-      int answer = 42;
-      assertEquals(42, answer);
-    });
-  }
+	public void declareSpecs(JavaSpec javaspec) {
+		javaspec.it("answers the meaning of life", () -> {
+			int answer = 42;
+			assertEquals(42, answer);
+		});
+	}
 
-  private static void assertEquals(int expected, int actual) {
-    if(actual == expected)
-      return;
+	private static void assertEquals(int expected, int actual) {
+		if (actual == expected)
+			return;
 
-    throw new AssertionError(String.format(
-      "Expected <%s>, but was <%s>",
-      expected,
-      actual
-    ));
-  }
+		throw new AssertionError(String.format("Expected <%s>, but was <%s>", expected, actual));
+	}
 }

--- a/prototypes/javaspec-engine-discovery-request-listener/build.gradle
+++ b/prototypes/javaspec-engine-discovery-request-listener/build.gradle
@@ -1,15 +1,15 @@
 //Service provider for EngineDiscoveryRequestListener
 plugins {
-  id 'java-library'
+	id 'java-library'
 }
 
 dependencies {
-  implementation project(':javaspec-engine')
-  implementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+	implementation project(':javaspec-engine')
+	implementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
 test {
-  useJUnitPlatform()
+	useJUnitPlatform()
 }
 
 version '0.0.1'

--- a/prototypes/javaspec-engine-discovery-request-listener/build.gradle
+++ b/prototypes/javaspec-engine-discovery-request-listener/build.gradle
@@ -3,18 +3,13 @@ plugins {
   id 'java-library'
 }
 
-group 'info.javaspec'
-version '0.0.1'
-
 dependencies {
   implementation project(':javaspec-engine')
   implementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
-repositories {
-  mavenCentral()
-}
-
 test {
   useJUnitPlatform()
 }
+
+version '0.0.1'

--- a/prototypes/javaspec-engine-discovery-request-listener/build.gradle
+++ b/prototypes/javaspec-engine-discovery-request-listener/build.gradle
@@ -1,11 +1,18 @@
 //Service provider for EngineDiscoveryRequestListener
 plugins {
 	id 'java-library'
+	id 'com.diffplug.spotless'
 }
 
 dependencies {
 	implementation project(':javaspec-engine')
 	implementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+}
+
+spotless {
+	java {
+		eclipse()
+	}
 }
 
 test {

--- a/prototypes/javaspec-engine-discovery-request-listener/src/main/java/info/javaspec/engine/ConsoleEngineDiscoveryRequestListener.java
+++ b/prototypes/javaspec-engine-discovery-request-listener/src/main/java/info/javaspec/engine/ConsoleEngineDiscoveryRequestListener.java
@@ -6,61 +6,59 @@ import org.junit.platform.engine.discovery.*;
 //Prints JavaSpec's EngineDiscoveryRequest to the console
 //Load via ServiceLoader: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html?is-external=true#load(java.lang.Class)
 public class ConsoleEngineDiscoveryRequestListener implements EngineDiscoveryRequestListener {
-  @Override
-  public void onDiscover(EngineDiscoveryRequest discoveryRequest) {
-    System.out.println();
-    System.out.printf("[ConsoleEngineDiscoveryRequestListener] ClasspathResourceSelector%n");
-    discoveryRequest.getSelectorsByType(ClasspathResourceSelector.class)
-      .forEach(x -> System.out.printf("- %s%n", x.getClasspathResourceName()));
+	@Override
+	public void onDiscover(EngineDiscoveryRequest discoveryRequest) {
+		System.out.println();
+		System.out.printf("[ConsoleEngineDiscoveryRequestListener] ClasspathResourceSelector%n");
+		discoveryRequest.getSelectorsByType(ClasspathResourceSelector.class)
+				.forEach(x -> System.out.printf("- %s%n", x.getClasspathResourceName()));
 
-    System.out.println();
-    System.out.printf("[ConsoleEngineDiscoveryRequestListener] ClasspathRootSelector%n");
-    discoveryRequest.getSelectorsByType(ClasspathRootSelector.class)
-      .forEach(x -> System.out.printf("- %s%n", x.getClasspathRoot()));
+		System.out.println();
+		System.out.printf("[ConsoleEngineDiscoveryRequestListener] ClasspathRootSelector%n");
+		discoveryRequest.getSelectorsByType(ClasspathRootSelector.class)
+				.forEach(x -> System.out.printf("- %s%n", x.getClasspathRoot()));
 
-    System.out.println();
-    System.out.printf("[ConsoleEngineDiscoveryRequestListener] ClassSelector%n");
-    discoveryRequest.getSelectorsByType(ClassSelector.class)
-      .forEach(x -> System.out.printf("- %s%n", x.getClassName()));
+		System.out.println();
+		System.out.printf("[ConsoleEngineDiscoveryRequestListener] ClassSelector%n");
+		discoveryRequest.getSelectorsByType(ClassSelector.class)
+				.forEach(x -> System.out.printf("- %s%n", x.getClassName()));
 
-    System.out.println();
-    System.out.printf("[ConsoleEngineDiscoveryRequestListener] DirectorySelector%n");
-    discoveryRequest.getSelectorsByType(DirectorySelector.class)
-      .forEach(x -> System.out.printf("- %s%n", x.getRawPath()));
+		System.out.println();
+		System.out.printf("[ConsoleEngineDiscoveryRequestListener] DirectorySelector%n");
+		discoveryRequest.getSelectorsByType(DirectorySelector.class)
+				.forEach(x -> System.out.printf("- %s%n", x.getRawPath()));
 
-    System.out.println();
-    System.out.printf("[ConsoleEngineDiscoveryRequestListener] FileSelector%n");
-    discoveryRequest.getSelectorsByType(FileSelector.class)
-      .forEach(x -> System.out.printf("- %s%n", x.getRawPath()));
+		System.out.println();
+		System.out.printf("[ConsoleEngineDiscoveryRequestListener] FileSelector%n");
+		discoveryRequest.getSelectorsByType(FileSelector.class)
+				.forEach(x -> System.out.printf("- %s%n", x.getRawPath()));
 
-    System.out.println();
-    System.out.printf("[ConsoleEngineDiscoveryRequestListener] MethodSelector%n");
-    discoveryRequest.getSelectorsByType(MethodSelector.class)
-      .forEach(x -> System.out.printf("- %s#%s%n", x.getClassName(), x.getMethodName()));
+		System.out.println();
+		System.out.printf("[ConsoleEngineDiscoveryRequestListener] MethodSelector%n");
+		discoveryRequest.getSelectorsByType(MethodSelector.class)
+				.forEach(x -> System.out.printf("- %s#%s%n", x.getClassName(), x.getMethodName()));
 
-    System.out.println();
-    System.out.printf("[ConsoleEngineDiscoveryRequestListener] PackageSelector%n");
-    discoveryRequest.getSelectorsByType(PackageSelector.class)
-      .forEach(x -> System.out.printf("- %s%n", x.getPackageName()));
+		System.out.println();
+		System.out.printf("[ConsoleEngineDiscoveryRequestListener] PackageSelector%n");
+		discoveryRequest.getSelectorsByType(PackageSelector.class)
+				.forEach(x -> System.out.printf("- %s%n", x.getPackageName()));
 
-    System.out.println();
-    System.out.printf("[ConsoleEngineDiscoveryRequestListener] UniqueIdSelector%n");
-    discoveryRequest.getSelectorsByType(UniqueIdSelector.class)
-      .forEach(x -> System.out.printf("- %s%n", x.getUniqueId()));
+		System.out.println();
+		System.out.printf("[ConsoleEngineDiscoveryRequestListener] UniqueIdSelector%n");
+		discoveryRequest.getSelectorsByType(UniqueIdSelector.class)
+				.forEach(x -> System.out.printf("- %s%n", x.getUniqueId()));
 
-    System.out.println();
-    System.out.printf("[ConsoleEngineDiscoveryRequestListener] UriSelector%n");
-    discoveryRequest.getSelectorsByType(UriSelector.class)
-      .forEach(x -> System.out.printf("- %s%n", x.getUri().getRawPath()));
+		System.out.println();
+		System.out.printf("[ConsoleEngineDiscoveryRequestListener] UriSelector%n");
+		discoveryRequest.getSelectorsByType(UriSelector.class)
+				.forEach(x -> System.out.printf("- %s%n", x.getUri().getRawPath()));
 
-    System.out.println();
-    System.out.printf("[ConsoleEngineDiscoveryRequestListener] ClassNameFilter%n");
-    discoveryRequest.getFiltersByType(ClassNameFilter.class)
-      .forEach(x -> System.out.printf("- %s%n", x));
+		System.out.println();
+		System.out.printf("[ConsoleEngineDiscoveryRequestListener] ClassNameFilter%n");
+		discoveryRequest.getFiltersByType(ClassNameFilter.class).forEach(x -> System.out.printf("- %s%n", x));
 
-    System.out.println();
-    System.out.printf("[ConsoleEngineDiscoveryRequestListener] PackageNameFilter%n");
-    discoveryRequest.getFiltersByType(PackageNameFilter.class)
-      .forEach(x -> System.out.printf("- %s%n", x));
-  }
+		System.out.println();
+		System.out.printf("[ConsoleEngineDiscoveryRequestListener] PackageNameFilter%n");
+		discoveryRequest.getFiltersByType(PackageNameFilter.class).forEach(x -> System.out.printf("- %s%n", x));
+	}
 }

--- a/prototypes/javaspec-engine/build.gradle
+++ b/prototypes/javaspec-engine/build.gradle
@@ -1,11 +1,8 @@
 //JUnit TestEngine that is discovered at runtime and runs specs under JUnit Jupiter
 plugins {
   id 'java-library'
-  id 'com.adarshr.test-logger' version '3.1.0'
+  id 'com.adarshr.test-logger'
 }
-
-group 'info.javaspec'
-version '0.0.1'
 
 dependencies {
   implementation project(':javaspec-api')
@@ -13,10 +10,6 @@ dependencies {
 
   testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
   testImplementation 'org.junit.platform:junit-platform-testkit:1.8.2'
-}
-
-repositories {
-  mavenCentral()
 }
 
 test {
@@ -29,3 +22,5 @@ test {
 testlogger {
   theme 'mocha'
 }
+
+version '0.0.1'

--- a/prototypes/javaspec-engine/build.gradle
+++ b/prototypes/javaspec-engine/build.gradle
@@ -1,26 +1,26 @@
 //JUnit TestEngine that is discovered at runtime and runs specs under JUnit Jupiter
 plugins {
-  id 'java-library'
-  id 'com.adarshr.test-logger'
+	id 'java-library'
+	id 'com.adarshr.test-logger'
 }
 
 dependencies {
-  implementation project(':javaspec-api')
-  implementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+	implementation project(':javaspec-api')
+	implementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 
-  testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
-  testImplementation 'org.junit.platform:junit-platform-testkit:1.8.2'
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+	testImplementation 'org.junit.platform:junit-platform-testkit:1.8.2'
 }
 
 test {
-  useJUnitPlatform {
-    excludeEngines 'javaspec-engine' //Run with the default engine, not one we're building
-  }
+	useJUnitPlatform {
+		excludeEngines 'javaspec-engine' //Run with the default engine, not one we're building
+	}
 }
 
 //https://github.com/radarsh/gradle-test-logger-plugin
 testlogger {
-  theme 'mocha'
+	theme 'mocha'
 }
 
 version '0.0.1'

--- a/prototypes/javaspec-engine/build.gradle
+++ b/prototypes/javaspec-engine/build.gradle
@@ -2,6 +2,7 @@
 plugins {
 	id 'java-library'
 	id 'com.adarshr.test-logger'
+	id 'com.diffplug.spotless'
 }
 
 dependencies {
@@ -10,6 +11,12 @@ dependencies {
 
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
 	testImplementation 'org.junit.platform:junit-platform-testkit:1.8.2'
+}
+
+spotless {
+	java {
+		eclipse()
+	}
 }
 
 test {

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/EngineDiscoveryRequestListener.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/EngineDiscoveryRequestListener.java
@@ -4,5 +4,5 @@ import org.junit.platform.engine.EngineDiscoveryRequest;
 
 //Receives an EngineDiscoveryRequest, upon discovery
 public interface EngineDiscoveryRequestListener {
-  void onDiscover(EngineDiscoveryRequest discoveryRequest);
+	void onDiscover(EngineDiscoveryRequest discoveryRequest);
 }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -12,91 +12,88 @@ import java.util.ServiceLoader;
 
 //Discovers specs, turns them into something Jupiter can run, and runs them.
 public class JavaSpecEngine implements TestEngine {
-  @Override
-  public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId engineId) {
-    ServiceLoader<EngineDiscoveryRequestListener> loader = ServiceLoader.load(EngineDiscoveryRequestListener.class);
-    loader.findFirst().ifPresent(x -> x.onDiscover(discoveryRequest));
+	@Override
+	public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId engineId) {
+		ServiceLoader<EngineDiscoveryRequestListener> loader = ServiceLoader.load(EngineDiscoveryRequestListener.class);
+		loader.findFirst().ifPresent(x -> x.onDiscover(discoveryRequest));
 
-    EngineDescriptor engineDescriptor = new EngineDescriptor(engineId, "JavaSpec");
-    discoveryRequest.getSelectorsByType(ClassSelector.class).stream()
-      .map(ClassSelector::getJavaClass)
-      .filter(selectedClass -> SpecClass.class.isAssignableFrom(selectedClass))
-      .map(selectedClass -> (Class<SpecClass>) selectedClass)
-      .map(specClass -> makeDeclaringInstance(specClass))
-      .forEach(declaringInstance -> {
-        JavaSpecForJupiter javaspec = JavaSpecForJupiter.forSpecClass(engineId, declaringInstance.getClass());
-        declaringInstance.declareSpecs(javaspec);
-        javaspec.addDescriptorsTo(engineDescriptor);
-      });
+		EngineDescriptor engineDescriptor = new EngineDescriptor(engineId, "JavaSpec");
+		discoveryRequest.getSelectorsByType(ClassSelector.class).stream().map(ClassSelector::getJavaClass)
+				.filter(selectedClass -> SpecClass.class.isAssignableFrom(selectedClass))
+				.map(selectedClass -> (Class<SpecClass>) selectedClass)
+				.map(specClass -> makeDeclaringInstance(specClass)).forEach(declaringInstance -> {
+					JavaSpecForJupiter javaspec = JavaSpecForJupiter.forSpecClass(engineId,
+							declaringInstance.getClass());
+					declaringInstance.declareSpecs(javaspec);
+					javaspec.addDescriptorsTo(engineDescriptor);
+				});
 
-    return engineDescriptor;
-  }
+		return engineDescriptor;
+	}
 
-  private SpecClass makeDeclaringInstance(Class<SpecClass> specClass) {
-    Constructor<SpecClass> constructor = null;
-    try {
-      constructor = specClass.getDeclaredConstructor();
-    } catch (NoSuchMethodException e) {
-      throw new RuntimeException("Failed to access no-arg SpecClass constructor", e);
-    }
+	private SpecClass makeDeclaringInstance(Class<SpecClass> specClass) {
+		Constructor<SpecClass> constructor = null;
+		try {
+			constructor = specClass.getDeclaredConstructor();
+		} catch (NoSuchMethodException e) {
+			throw new RuntimeException("Failed to access no-arg SpecClass constructor", e);
+		}
 
-    try {
-      return constructor.newInstance();
-    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-      throw new RuntimeException("Failed to instantiate SpecClass", e);
-    }
-  }
+		try {
+			return constructor.newInstance();
+		} catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+			throw new RuntimeException("Failed to instantiate SpecClass", e);
+		}
+	}
 
-  @Override
-  public void execute(ExecutionRequest request) {
-    execute(
-      request.getRootTestDescriptor(),
-      request.getEngineExecutionListener());
-  }
+	@Override
+	public void execute(ExecutionRequest request) {
+		execute(request.getRootTestDescriptor(), request.getEngineExecutionListener());
+	}
 
-  private void execute(TestDescriptor descriptor, EngineExecutionListener listener) {
-    switch (descriptor.getType()) {
-      case CONTAINER:
-        listener.executionStarted(descriptor);
-        for (TestDescriptor child : descriptor.getChildren())
-          execute(child, listener);
+	private void execute(TestDescriptor descriptor, EngineExecutionListener listener) {
+		switch (descriptor.getType()) {
+			case CONTAINER :
+				listener.executionStarted(descriptor);
+				for (TestDescriptor child : descriptor.getChildren())
+					execute(child, listener);
 
-        listener.executionFinished(descriptor, TestExecutionResult.successful());
-        return;
+				listener.executionFinished(descriptor, TestExecutionResult.successful());
+				return;
 
-      case TEST:
-        listener.executionStarted(descriptor);
-        try {
-          JupiterSpec spec = (JupiterSpec) descriptor;
-          spec.run();
-        } catch (AssertionError | Exception e) {
-          listener.executionFinished(descriptor, TestExecutionResult.failed(e));
-          return;
-        }
+			case TEST :
+				listener.executionStarted(descriptor);
+				try {
+					JupiterSpec spec = (JupiterSpec) descriptor;
+					spec.run();
+				} catch (AssertionError | Exception e) {
+					listener.executionFinished(descriptor, TestExecutionResult.failed(e));
+					return;
+				}
 
-        listener.executionFinished(descriptor, TestExecutionResult.successful());
-        return;
+				listener.executionFinished(descriptor, TestExecutionResult.successful());
+				return;
 
-      case CONTAINER_AND_TEST:
-        listener.executionStarted(descriptor);
-        for (TestDescriptor child : descriptor.getChildren())
-          execute(child, listener);
+			case CONTAINER_AND_TEST :
+				listener.executionStarted(descriptor);
+				for (TestDescriptor child : descriptor.getChildren())
+					execute(child, listener);
 
-        try {
-          JupiterSpec spec = (JupiterSpec) descriptor;
-          spec.run();
-        } catch (AssertionError | Exception e) {
-          listener.executionFinished(descriptor, TestExecutionResult.failed(e));
-          return;
-        }
+				try {
+					JupiterSpec spec = (JupiterSpec) descriptor;
+					spec.run();
+				} catch (AssertionError | Exception e) {
+					listener.executionFinished(descriptor, TestExecutionResult.failed(e));
+					return;
+				}
 
-        listener.executionFinished(descriptor, TestExecutionResult.successful());
-        return;
-    }
-  }
+				listener.executionFinished(descriptor, TestExecutionResult.successful());
+				return;
+		}
+	}
 
-  @Override
-  public String getId() {
-    return "javaspec-engine";
-  }
+	@Override
+	public String getId() {
+		return "javaspec-engine";
+	}
 }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecForJupiter.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecForJupiter.java
@@ -12,40 +12,33 @@ import java.util.Optional;
 
 //A JavaSpec declaration that runs 1 or more specs on JUnit
 public class JavaSpecForJupiter extends AbstractTestDescriptor implements JavaSpec {
-  private final List<JupiterSpec> specs;
+	private final List<JupiterSpec> specs;
 
-  public static JavaSpecForJupiter forSpecClass(UniqueId parentId, Class<?> specClass) {
-    return new JavaSpecForJupiter(
-      parentId.append("class", specClass.getName()),
-      specClass.getName()
-    );
-  }
+	public static JavaSpecForJupiter forSpecClass(UniqueId parentId, Class<?> specClass) {
+		return new JavaSpecForJupiter(parentId.append("class", specClass.getName()), specClass.getName());
+	}
 
-  private JavaSpecForJupiter(UniqueId uniqueId, String displayName) {
-    super(uniqueId, displayName);
-    this.specs = new LinkedList<>();
-  }
+	private JavaSpecForJupiter(UniqueId uniqueId, String displayName) {
+		super(uniqueId, displayName);
+		this.specs = new LinkedList<>();
+	}
 
-  /* Jupiter */
+	/* Jupiter */
 
-  @Override
-  public Type getType() {
-    return Type.CONTAINER;
-  }
+	@Override
+	public Type getType() {
+		return Type.CONTAINER;
+	}
 
-  public void addDescriptorsTo(TestDescriptor parentDescriptor) {
-    parentDescriptor.addChild(this);
-    this.specs.forEach(x -> x.addTestDescriptorTo(this));
-  }
+	public void addDescriptorsTo(TestDescriptor parentDescriptor) {
+		parentDescriptor.addChild(this);
+		this.specs.forEach(x -> x.addTestDescriptorTo(this));
+	}
 
-  /* JavaSpec syntax */
+	/* JavaSpec syntax */
 
-  @Override
-  public void it(String behavior, Verification verification) {
-    this.specs.add(JupiterSpec.forBehavior(
-      getUniqueId(),
-      behavior,
-      verification
-    ));
-  }
+	@Override
+	public void it(String behavior, Verification verification) {
+		this.specs.add(JupiterSpec.forBehavior(getUniqueId(), behavior, verification));
+	}
 }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JupiterSpec.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JupiterSpec.java
@@ -7,31 +7,27 @@ import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 
 //A spec that runs on JUnit
 public class JupiterSpec extends AbstractTestDescriptor {
-  private final Verification verification;
+	private final Verification verification;
 
-  public static JupiterSpec forBehavior(UniqueId parentId, String behavior, Verification verification) {
-    return new JupiterSpec(
-      parentId.append("spec", behavior),
-      behavior,
-      verification
-    );
-  }
+	public static JupiterSpec forBehavior(UniqueId parentId, String behavior, Verification verification) {
+		return new JupiterSpec(parentId.append("spec", behavior), behavior, verification);
+	}
 
-  private JupiterSpec(UniqueId uniqueId, String displayName, Verification verification) {
-    super(uniqueId, displayName);
-    this.verification = verification;
-  }
+	private JupiterSpec(UniqueId uniqueId, String displayName, Verification verification) {
+		super(uniqueId, displayName);
+		this.verification = verification;
+	}
 
-  public void addTestDescriptorTo(TestDescriptor parentDescriptor) {
-    parentDescriptor.addChild(this);
-  }
+	public void addTestDescriptorTo(TestDescriptor parentDescriptor) {
+		parentDescriptor.addChild(this);
+	}
 
-  @Override
-  public Type getType() {
-    return Type.TEST;
-  }
+	@Override
+	public Type getType() {
+		return Type.TEST;
+	}
 
-  public void run() {
-    this.verification.execute();
-  }
+	public void run() {
+		this.verification.execute();
+	}
 }

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/EmptySpecs.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/EmptySpecs.java
@@ -5,6 +5,7 @@ import info.javaspec.api.SpecClass;
 
 //An empty class that has no specs in it.
 public class EmptySpecs implements SpecClass {
-  @Override
-  public void declareSpecs(JavaSpec javaspec) { /* empty */ }
+	@Override
+	public void declareSpecs(JavaSpec javaspec) {
+		/* empty */ }
 }

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -11,76 +11,63 @@ import static org.junit.platform.testkit.engine.EventConditions.*;
 
 @DisplayName("JavaSpecEngine")
 public class JavaSpecEngineTest {
-  @Test
-  @DisplayName("runs a test container for the engine itself")
-  public void runsASpecForTheContainingClass() throws Exception {
-    EngineExecutionResults results = EngineTestKit.engine("javaspec-engine")
-      .execute();
+	@Test
+	@DisplayName("runs a test container for the engine itself")
+	public void runsASpecForTheContainingClass() throws Exception {
+		EngineExecutionResults results = EngineTestKit.engine("javaspec-engine").execute();
 
-    results.containerEvents().assertEventsMatchExactly(
-      event(engine(), started()),
-      event(engine(), finishedSuccessfully())
-    );
-  }
+		results.containerEvents().assertEventsMatchExactly(event(engine(), started()),
+				event(engine(), finishedSuccessfully()));
+	}
 
-  @Nested
-  @DisplayName("given a SpecClass without any specs in it")
-  class givenASpecClassWithNoSpecs {
-    @Test
-    @DisplayName("does not run any containers for the spec class")
-    public void runsNoContainerForTheClass() throws Exception {
-      EngineExecutionResults results = EngineTestKit.engine("javaspec-engine")
-        .selectors(selectClass(EmptySpecs.class))
-        .execute();
+	@Nested
+	@DisplayName("given a SpecClass without any specs in it")
+	class givenASpecClassWithNoSpecs {
+		@Test
+		@DisplayName("does not run any containers for the spec class")
+		public void runsNoContainerForTheClass() throws Exception {
+			EngineExecutionResults results = EngineTestKit.engine("javaspec-engine")
+					.selectors(selectClass(EmptySpecs.class)).execute();
 
-      results.containerEvents().assertEventsMatchExactly(
-        event(engine(), started()),
-        event(engine(), finishedSuccessfully())
-      );
-    }
+			results.containerEvents().assertEventsMatchExactly(event(engine(), started()),
+					event(engine(), finishedSuccessfully()));
+		}
 
-    @Test
-    @DisplayName("does not run any tests for specs")
-    public void runsNoTests() throws Exception {
-      EngineExecutionResults results = EngineTestKit.engine("javaspec-engine")
-        .selectors(selectClass(EmptySpecs.class))
-        .execute();
+		@Test
+		@DisplayName("does not run any tests for specs")
+		public void runsNoTests() throws Exception {
+			EngineExecutionResults results = EngineTestKit.engine("javaspec-engine")
+					.selectors(selectClass(EmptySpecs.class)).execute();
 
-      results.testEvents().assertEventsMatchExactly();
-    }
-  }
+			results.testEvents().assertEventsMatchExactly();
+		}
+	}
 
-  @Nested
-  @DisplayName("given a SpecClass with 1 or more specs")
-  class givenASpecClassWithSpecs {
-    @Test
-    @DisplayName("runs a test for the class itself, within the engine's container")
-    public void runsATestForTheClass() throws Exception {
-      EngineExecutionResults results = EngineTestKit.engine("javaspec-engine")
-        .selectors(selectClass(OneFlatSpecs.class))
-        .execute();
+	@Nested
+	@DisplayName("given a SpecClass with 1 or more specs")
+	class givenASpecClassWithSpecs {
+		@Test
+		@DisplayName("runs a test for the class itself, within the engine's container")
+		public void runsATestForTheClass() throws Exception {
+			EngineExecutionResults results = EngineTestKit.engine("javaspec-engine")
+					.selectors(selectClass(OneFlatSpecs.class)).execute();
 
-      results.containerEvents().assertEventsMatchExactly(
-        event(engine(), started()),
-        event(container("class:info.javaspec.engine.OneFlatSpecs"), started()),
-        event(container("class:info.javaspec.engine.OneFlatSpecs"), finishedSuccessfully()),
-        event(engine(), finishedSuccessfully())
-      );
-    }
+			results.containerEvents().assertEventsMatchExactly(event(engine(), started()),
+					event(container("class:info.javaspec.engine.OneFlatSpecs"), started()),
+					event(container("class:info.javaspec.engine.OneFlatSpecs"), finishedSuccessfully()),
+					event(engine(), finishedSuccessfully()));
+		}
 
-    @Test
-    @DisplayName("runs a test for the spec, within the class's container")
-    public void runsATestForTheSpec() throws Exception {
-      EngineExecutionResults results = EngineTestKit.engine("javaspec-engine")
-        .selectors(selectClass(OneFlatSpecs.class))
-        .execute();
+		@Test
+		@DisplayName("runs a test for the spec, within the class's container")
+		public void runsATestForTheSpec() throws Exception {
+			EngineExecutionResults results = EngineTestKit.engine("javaspec-engine")
+					.selectors(selectClass(OneFlatSpecs.class)).execute();
 
-      results.allEvents().assertEventsMatchLooselyInOrder(
-        event(container("class:info.javaspec.engine.OneFlatSpecs"), started()),
-        event(test("spec:works"), started()),
-        event(test("spec:works"), finishedSuccessfully()),
-        event(container("class:info.javaspec.engine.OneFlatSpecs"), finishedSuccessfully())
-      );
-    }
-  }
+			results.allEvents().assertEventsMatchLooselyInOrder(
+					event(container("class:info.javaspec.engine.OneFlatSpecs"), started()),
+					event(test("spec:works"), started()), event(test("spec:works"), finishedSuccessfully()),
+					event(container("class:info.javaspec.engine.OneFlatSpecs"), finishedSuccessfully()));
+		}
+	}
 }

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/OneFlatSpecs.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/OneFlatSpecs.java
@@ -5,8 +5,9 @@ import info.javaspec.api.SpecClass;
 
 //Declares a single spec
 public class OneFlatSpecs implements SpecClass {
-  @Override
-  public void declareSpecs(JavaSpec javaspec) {
-    javaspec.it("works", () -> {});
-  }
+	@Override
+	public void declareSpecs(JavaSpec javaspec) {
+		javaspec.it("works", () -> {
+		});
+	}
 }

--- a/prototypes/jupiter-adapters/build.gradle
+++ b/prototypes/jupiter-adapters/build.gradle
@@ -1,21 +1,21 @@
 //Prototype adapters of JavaSpec syntax to JUnit 5 constructs
 plugins {
-  id 'java-library'
-  id 'com.adarshr.test-logger'
+	id 'java-library'
+	id 'com.adarshr.test-logger'
 }
 
 dependencies {
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
 test {
-  useJUnitPlatform()
+	useJUnitPlatform()
 }
 
 //https://github.com/radarsh/gradle-test-logger-plugin
 testlogger {
-  theme 'mocha'
+	theme 'mocha'
 }
 
 version '0.0.1'

--- a/prototypes/jupiter-adapters/build.gradle
+++ b/prototypes/jupiter-adapters/build.gradle
@@ -1,19 +1,12 @@
 //Prototype adapters of JavaSpec syntax to JUnit 5 constructs
 plugins {
   id 'java-library'
-  id 'com.adarshr.test-logger' version '3.1.0'
+  id 'com.adarshr.test-logger'
 }
-
-group 'info.javaspec'
-version '0.0.1'
 
 dependencies {
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-}
-
-repositories {
-  mavenCentral()
 }
 
 test {
@@ -24,3 +17,5 @@ test {
 testlogger {
   theme 'mocha'
 }
+
+version '0.0.1'

--- a/prototypes/jupiter-freestanding/build.gradle
+++ b/prototypes/jupiter-freestanding/build.gradle
@@ -1,21 +1,21 @@
 //Self-contained prototype JUnit 5 Launcher and TestEngine that runs from a main class
 plugins {
-  id 'application'
+	id 'application'
 }
 
 application {
-  mainClass = 'info.javaspec.engine.Main'
+	mainClass = 'info.javaspec.engine.Main'
 }
 
 //Does not depend upon any other JavaSpec artifacts.
 dependencies {
-  implementation 'org.junit.jupiter:junit-jupiter:5.8.2'
-  implementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-  implementation 'org.junit.platform:junit-platform-launcher:1.8.2'
+	implementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+	implementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+	implementation 'org.junit.platform:junit-platform-launcher:1.8.2'
 }
 
 test {
-  useJUnitPlatform()
+	useJUnitPlatform()
 }
 
 version '0.0.1'

--- a/prototypes/jupiter-freestanding/build.gradle
+++ b/prototypes/jupiter-freestanding/build.gradle
@@ -3,9 +3,6 @@ plugins {
   id 'application'
 }
 
-group 'info.javaspec'
-version '0.0.1'
-
 application {
   mainClass = 'info.javaspec.engine.Main'
 }
@@ -17,10 +14,8 @@ dependencies {
   implementation 'org.junit.platform:junit-platform-launcher:1.8.2'
 }
 
-repositories {
-  mavenCentral()
-}
-
 test {
   useJUnitPlatform()
 }
+
+version '0.0.1'

--- a/prototypes/jupiter-test-execution-listener/build.gradle
+++ b/prototypes/jupiter-test-execution-listener/build.gradle
@@ -1,14 +1,14 @@
 //Exports a service that reports test execution events to the console
 plugins {
-  id 'java-library'
+	id 'java-library'
 }
 
 dependencies {
-  implementation 'org.junit.platform:junit-platform-launcher:1.8.1'
+	implementation 'org.junit.platform:junit-platform-launcher:1.8.1'
 }
 
 test {
-  useJUnitPlatform()
+	useJUnitPlatform()
 }
 
 version '0.0.1'

--- a/prototypes/jupiter-test-execution-listener/build.gradle
+++ b/prototypes/jupiter-test-execution-listener/build.gradle
@@ -1,10 +1,17 @@
 //Exports a service that reports test execution events to the console
 plugins {
 	id 'java-library'
+	id 'com.diffplug.spotless'
 }
 
 dependencies {
 	implementation 'org.junit.platform:junit-platform-launcher:1.8.1'
+}
+
+spotless {
+	java {
+		eclipse()
+	}
 }
 
 test {

--- a/prototypes/jupiter-test-execution-listener/build.gradle
+++ b/prototypes/jupiter-test-execution-listener/build.gradle
@@ -3,17 +3,12 @@ plugins {
   id 'java-library'
 }
 
-group 'info.javaspec'
-version '0.0.1'
-
 dependencies {
   implementation 'org.junit.platform:junit-platform-launcher:1.8.1'
-}
-
-repositories {
-  mavenCentral()
 }
 
 test {
   useJUnitPlatform()
 }
+
+version '0.0.1'

--- a/prototypes/jupiter-test-execution-listener/src/main/java/info/javaspec/jupiter/ConsoleTestExecutionListener.java
+++ b/prototypes/jupiter-test-execution-listener/src/main/java/info/javaspec/jupiter/ConsoleTestExecutionListener.java
@@ -9,42 +9,42 @@ import org.junit.platform.launcher.TestPlan;
 //Logs events to the console
 //Register via: https://junit.org/junit5/docs/current/user-guide/#launcher-api-launcher-discovery-listeners-custom
 public class ConsoleTestExecutionListener implements TestExecutionListener {
-  public ConsoleTestExecutionListener() { /* Required as service wrapper */ }
+	public ConsoleTestExecutionListener() {
+		/* Required as service wrapper */ }
 
-  @Override
-  public void testPlanExecutionStarted(TestPlan plan) {
-    System.out.printf(
-      "[ConsoleTestExecutionListener#testPlanExecutionStarted] %d tests%n",
-      plan.countTestIdentifiers(x -> true));
-  }
+	@Override
+	public void testPlanExecutionStarted(TestPlan plan) {
+		System.out.printf("[ConsoleTestExecutionListener#testPlanExecutionStarted] %d tests%n",
+				plan.countTestIdentifiers(x -> true));
+	}
 
-  @Override
-  public void testPlanExecutionFinished(TestPlan plan) {
-    System.out.printf("[ConsoleTestExecutionListener#testPlanExecutionFinished]%n");
-  }
+	@Override
+	public void testPlanExecutionFinished(TestPlan plan) {
+		System.out.printf("[ConsoleTestExecutionListener#testPlanExecutionFinished]%n");
+	}
 
-  @Override
-  public void dynamicTestRegistered(TestIdentifier id) {
-    System.out.printf("[ConsoleTestExecutionListener#dynamicTestRegistered] %s%n", id);
-  }
+	@Override
+	public void dynamicTestRegistered(TestIdentifier id) {
+		System.out.printf("[ConsoleTestExecutionListener#dynamicTestRegistered] %s%n", id);
+	}
 
-  @Override
-  public void executionSkipped(TestIdentifier id, String reason) {
-    System.out.printf("[ConsoleTestExecutionListener#executionSkipped] %s: %s%n", id, reason);
-  }
+	@Override
+	public void executionSkipped(TestIdentifier id, String reason) {
+		System.out.printf("[ConsoleTestExecutionListener#executionSkipped] %s: %s%n", id, reason);
+	}
 
-  @Override
-  public void executionStarted(TestIdentifier id) {
-    System.out.printf("[ConsoleTestExecutionListener#executionStarted] %s%n", id);
-  }
+	@Override
+	public void executionStarted(TestIdentifier id) {
+		System.out.printf("[ConsoleTestExecutionListener#executionStarted] %s%n", id);
+	}
 
-  @Override
-  public void executionFinished(TestIdentifier id, TestExecutionResult result) {
-    System.out.printf("[ConsoleTestExecutionListener#executionFinished] %s: %s%n", id, result);
-  }
+	@Override
+	public void executionFinished(TestIdentifier id, TestExecutionResult result) {
+		System.out.printf("[ConsoleTestExecutionListener#executionFinished] %s: %s%n", id, result);
+	}
 
-  @Override
-  public void reportingEntryPublished(TestIdentifier id, ReportEntry entry) {
-    System.out.printf("[ConsoleTestExecutionListener#reportingEntryPublished] %s: %s%n", id, entry);
-  }
+	@Override
+	public void reportingEntryPublished(TestIdentifier id, ReportEntry entry) {
+		System.out.printf("[ConsoleTestExecutionListener#reportingEntryPublished] %s: %s%n", id, entry);
+	}
 }


### PR DESCRIPTION
It was starting to get annoying not having a standardized format for the new prototype code, so I used Spotless to apply the Eclipse formatter with default settings.  After an infuriating experience with the endlessly-configurable and -incompatible Checkstyle, I picked the formatter whose default configuration suited the existing style the best.  So while I don't prefer every single decision that this formatter makes, there's value in not having to mess with configuring it.

There's an `.editorconfig` to throw your editor a bone about what new code should look like.  Use `./gradlew spotlessCheck | spotlessApply` to check and format the code, respectively.

I guess this means I'm back to being a tabs person.  Laziness triumphs again!