### PR TITLE
Prototype: Add support for pending specs

### DIFF
--- a/prototypes/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
+++ b/prototypes/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
@@ -3,4 +3,5 @@ package info.javaspec.api;
 //Entrypoint for all syntax used to write specs in JavaSpec
 public interface JavaSpec {
 	void it(String behavior, Verification verification);
+	void pending(String futureBehavior);
 }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecDescriptor.java
@@ -1,0 +1,8 @@
+package info.javaspec.engine;
+
+import org.junit.platform.engine.EngineExecutionListener;
+
+//Adapter for a JavaSpec container or test of some sort that works likes its Jupiter counterpart.
+interface JavaSpecDescriptor {
+	void execute(EngineExecutionListener listener);
+}

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -60,6 +60,12 @@ public class JavaSpecEngine implements TestEngine {
 	}
 
 	private void execute(TestDescriptor descriptor, EngineExecutionListener listener) {
+		if (descriptor instanceof PendingSpecDescriptor) {
+			listener.executionStarted(descriptor);
+			listener.executionSkipped(descriptor, "pending");
+			return;
+		}
+
 		switch (descriptor.getType()) {
 		case CONTAINER:
 			listener.executionStarted(descriptor);

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -61,8 +61,8 @@ public class JavaSpecEngine implements TestEngine {
 
 	private void execute(TestDescriptor descriptor, EngineExecutionListener listener) {
 		if (descriptor instanceof PendingSpecDescriptor) {
-			listener.executionStarted(descriptor);
-			listener.executionSkipped(descriptor, "pending");
+			PendingSpecDescriptor pendingDescriptor = PendingSpecDescriptor.class.cast(descriptor);
+			pendingDescriptor.execute(listener);
 			return;
 		}
 

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -78,17 +78,8 @@ public class JavaSpecEngine implements TestEngine {
 			return;
 
 		case TEST:
-			listener.executionStarted(descriptor);
 			SpecDescriptor spec = SpecDescriptor.class.cast(descriptor);
-
-			try {
-				spec.execute();
-			} catch (AssertionError | Exception e) {
-				listener.executionFinished(spec, TestExecutionResult.failed(e));
-				return;
-			}
-
-			listener.executionFinished(descriptor, TestExecutionResult.successful());
+			spec.execute(listener);
 			return;
 
 		default:

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -60,12 +60,6 @@ public class JavaSpecEngine implements TestEngine {
 	}
 
 	private void execute(TestDescriptor descriptor, EngineExecutionListener listener) {
-		if (descriptor instanceof PendingSpecDescriptor) {
-			PendingSpecDescriptor pendingDescriptor = PendingSpecDescriptor.class.cast(descriptor);
-			pendingDescriptor.execute(listener);
-			return;
-		}
-
 		switch (descriptor.getType()) {
 		case CONTAINER:
 			listener.executionStarted(descriptor);
@@ -78,7 +72,7 @@ public class JavaSpecEngine implements TestEngine {
 			return;
 
 		case TEST:
-			SpecDescriptor spec = SpecDescriptor.class.cast(descriptor);
+			JavaSpecDescriptor spec = JavaSpecDescriptor.class.cast(descriptor);
 			spec.execute(listener);
 			return;
 

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/PendingSpecDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/PendingSpecDescriptor.java
@@ -1,5 +1,6 @@
 package info.javaspec.engine;
 
+import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 
@@ -20,5 +21,8 @@ final class PendingSpecDescriptor extends AbstractTestDescriptor {
 
 	/* JavaSpec */
 
-	public void execute() { /* Do nothing */ }
+	public void execute(EngineExecutionListener listener) {
+		listener.executionStarted(this);
+		listener.executionSkipped(this, "pending");
+	}
 }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/PendingSpecDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/PendingSpecDescriptor.java
@@ -1,0 +1,24 @@
+package info.javaspec.engine;
+
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+
+//Adapter for a pending spec that makes it work like a skipped Jupiter test.
+final class PendingSpecDescriptor extends AbstractTestDescriptor {
+	public static PendingSpecDescriptor of(UniqueId parentId, String behavior) {
+		return new PendingSpecDescriptor(parentId.append("test", behavior), behavior);
+	}
+
+	private PendingSpecDescriptor(UniqueId uniqueId, String displayName) {
+		super(uniqueId, displayName);
+	}
+
+	@Override
+	public Type getType() {
+		return Type.TEST;
+	}
+
+	/* JavaSpec */
+
+	public void execute() { /* Do nothing */ }
+}

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/PendingSpecDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/PendingSpecDescriptor.java
@@ -5,7 +5,7 @@ import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 
 //Adapter for a pending spec that makes it work like a skipped Jupiter test.
-final class PendingSpecDescriptor extends AbstractTestDescriptor {
+final class PendingSpecDescriptor extends AbstractTestDescriptor implements JavaSpecDescriptor {
 	public static PendingSpecDescriptor of(UniqueId parentId, String behavior) {
 		return new PendingSpecDescriptor(parentId.append("test", behavior), behavior);
 	}
@@ -21,6 +21,7 @@ final class PendingSpecDescriptor extends AbstractTestDescriptor {
 
 	/* JavaSpec */
 
+	@Override
 	public void execute(EngineExecutionListener listener) {
 		listener.executionStarted(this);
 		listener.executionSkipped(this, "pending");

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
@@ -47,8 +47,7 @@ final class SpecClassDescriptor extends AbstractTestDescriptor implements JavaSp
 
 	@Override
 	public void pending(String futureBehavior) {
-		SpecDescriptor specDescriptor = SpecDescriptor.of(getUniqueId(), futureBehavior, () -> {
-		});
+		PendingSpecDescriptor specDescriptor = PendingSpecDescriptor.of(getUniqueId(), futureBehavior);
 		specDescriptor.setParent(this);
 		this.addChild(specDescriptor);
 	}

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
@@ -44,4 +44,12 @@ final class SpecClassDescriptor extends AbstractTestDescriptor implements JavaSp
 		specDescriptor.setParent(this);
 		this.addChild(specDescriptor);
 	}
+
+	@Override
+	public void pending(String futureBehavior) {
+		SpecDescriptor specDescriptor = SpecDescriptor.of(getUniqueId(), futureBehavior, () -> {
+		});
+		specDescriptor.setParent(this);
+		this.addChild(specDescriptor);
+	}
 }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecDescriptor.java
@@ -1,6 +1,8 @@
 package info.javaspec.engine;
 
 import info.javaspec.api.Verification;
+import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 
@@ -24,7 +26,16 @@ final class SpecDescriptor extends AbstractTestDescriptor {
 
 	/* JavaSpec */
 
-	public void execute() {
-		this.verification.execute();
+	public void execute(EngineExecutionListener listener) {
+		listener.executionStarted(this);
+
+		try {
+			this.verification.execute();
+		} catch (AssertionError | Exception e) {
+			listener.executionFinished(this, TestExecutionResult.failed(e));
+			return;
+		}
+
+		listener.executionFinished(this, TestExecutionResult.successful());
 	}
 }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecDescriptor.java
@@ -7,7 +7,7 @@ import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 
 //Adapter for a spec that makes it work like a Jupiter test.
-final class SpecDescriptor extends AbstractTestDescriptor {
+final class SpecDescriptor extends AbstractTestDescriptor implements JavaSpecDescriptor {
 	private final Verification verification;
 
 	public static SpecDescriptor of(UniqueId parentId, String behavior, Verification verification) {
@@ -26,6 +26,7 @@ final class SpecDescriptor extends AbstractTestDescriptor {
 
 	/* JavaSpec */
 
+	@Override
 	public void execute(EngineExecutionListener listener) {
 		listener.executionStarted(this);
 

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
@@ -68,4 +68,17 @@ public class AnonymousSpecClasses {
 			}
 		};
 	}
+
+	public static Class<? extends SpecClass> pendingSpecClass() {
+		return pendingSpecClassInstance().getClass();
+	}
+
+	private static SpecClass pendingSpecClassInstance() {
+		return new SpecClass() {
+			@Override
+			public void declareSpecs(JavaSpec javaspec) {
+				javaspec.pending("pending spec");
+			}
+		};
+	}
 }

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -27,6 +27,10 @@ import org.junit.platform.testkit.engine.EngineTestKit;
 public class JavaSpecEngineTest implements SpecClass {
 	@Override
 	public void declareSpecs(JavaSpec javaspec) {
+		javaspec.it("supports a pending spec", () -> {
+			assertEquals("passing", "pending");
+		});
+
 		javaspec.it("can be loaded with ServiceLoader and located by ID", () -> {
 			EngineTestKit.engine("javaspec-engine").selectors(selectClass(nullSpecClass())).execute();
 		});

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -27,10 +27,6 @@ import org.junit.platform.testkit.engine.EngineTestKit;
 public class JavaSpecEngineTest implements SpecClass {
 	@Override
 	public void declareSpecs(JavaSpec javaspec) {
-		javaspec.it("supports a pending spec", () -> {
-			assertEquals("passing", "pending");
-		});
-
 		javaspec.it("can be loaded with ServiceLoader and located by ID", () -> {
 			EngineTestKit.engine("javaspec-engine").selectors(selectClass(nullSpecClass())).execute();
 		});
@@ -89,6 +85,20 @@ public class JavaSpecEngineTest implements SpecClass {
 			assertTrue(onlyChild.isContainer());
 			assertFalse(onlyChild.isRoot());
 			assertFalse(onlyChild.isTest());
+		});
+
+		javaspec.it("#discover discovers a pending spec", () -> {
+			JavaSpecEngine subject = new JavaSpecEngine();
+			TestDescriptor returned = subject
+				.discover(classEngineDiscoveryRequest(pendingSpecClass()), UniqueId.forEngine(subject.getId()));
+
+			TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
+			assertEquals(1, specClassDescriptor.getChildren().size());
+
+			TestDescriptor specDescriptor = specClassDescriptor.getChildren().iterator().next();
+			UniqueId.Segment idSegment = specDescriptor.getUniqueId().getLastSegment();
+			assertEquals("test", idSegment.getType());
+			assertEquals("pending spec", idSegment.getValue());
 		});
 
 		javaspec.it("#discover discovers a test for each spec in a spec class", () -> {

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -150,6 +150,18 @@ public class JavaSpecEngineTest implements SpecClass {
 				);
 		});
 
+		javaspec.it("#execute reports start and skipped events for pending specs", () -> {
+			EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
+				.selectors(selectClass(pendingSpecClass()))
+				.execute();
+
+			results.allEvents()
+				.assertEventsMatchLooselyInOrder(
+					event(test(), started()),
+					event(test(), skippedWithReason("pending"))
+				);
+		});
+
 		javaspec.it("#execute reports start and successful finish events for passing specs", () -> {
 			EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
 				.selectors(selectClass(oneSpecClass()))


### PR DESCRIPTION
Add support for pending specs by saying `JavaSpec#pending(String)`.

This in turn drives the beginning of some much-needed polymorphism for executing pending and real specs, via `JavaSpecDescriptor#execute`.