### PR TITLE
Prototype: Add top-level describe block

### DIFF
--- a/prototypes/etc/eclipse-format.xml
+++ b/prototypes/etc/eclipse-format.xml
@@ -324,7 +324,7 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.keep_lambda_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_lambda_body_block_on_one_line" value="one_line_if_empty"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method" value="49"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.keep_record_constructor_on_one_line" value="one_line_never"/>

--- a/prototypes/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
+++ b/prototypes/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
@@ -2,6 +2,12 @@ package info.javaspec.api;
 
 //Entrypoint for all syntax used to write specs in JavaSpec
 public interface JavaSpec {
+	void describe(String what, BehaviorDeclaration declaration);
 	void it(String behavior, Verification verification);
 	void pending(String futureBehavior);
+
+	@FunctionalInterface
+	interface BehaviorDeclaration {
+		void declare();
+	}
 }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/DescribeDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/DescribeDescriptor.java
@@ -1,0 +1,20 @@
+package info.javaspec.engine;
+
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+
+//Adapter for describe block that makes it work like a Jupiter test container.
+final class DescribeDescriptor extends AbstractTestDescriptor {
+	public static DescribeDescriptor about(UniqueId parentId, String what) {
+		return new DescribeDescriptor(parentId.append("describe-block", what), what);
+	}
+
+	private DescribeDescriptor(UniqueId uniqueId, String displayName) {
+		super(uniqueId, displayName);
+	}
+
+	@Override
+	public Type getType() {
+		return Type.CONTAINER;
+	}
+}

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
@@ -53,6 +53,7 @@ final class SpecClassDescriptor extends AbstractTestDescriptor implements JavaSp
 
 		setCurrentContainer(child);
 		declaration.declare();
+		setCurrentContainer(this);
 	}
 
 	@Override

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
@@ -13,7 +13,7 @@ final class SpecClassDescriptor extends AbstractTestDescriptor implements JavaSp
 	private final SpecClass declaringInstance;
 
 	// TODO KDK: This will need to be a Stack, but how long can we get away with
-	// this?
+	// this? Maybe putting #it *after* #describe?
 	private TestDescriptor container;
 
 	public static SpecClassDescriptor of(UniqueId parentId, SpecClass declaringInstance) {
@@ -51,10 +51,7 @@ final class SpecClassDescriptor extends AbstractTestDescriptor implements JavaSp
 		DescribeDescriptor child = DescribeDescriptor.about(container.getUniqueId(), what);
 		container.addChild(child);
 
-		// I haven't added any notion of a stack to track the current context yet
-		// This will cause specs in the describe block to be children of this
-		// SpecClassDescriptor instead of DescribeDescriptor.
-		this.container = child;
+		setCurrentContainer(child);
 		declaration.declare();
 	}
 
@@ -74,5 +71,9 @@ final class SpecClassDescriptor extends AbstractTestDescriptor implements JavaSp
 
 	private TestDescriptor currentContainer() {
 		return this.container;
+	}
+
+	private void setCurrentContainer(TestDescriptor container) {
+		this.container = container;
 	}
 }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
@@ -55,19 +55,4 @@ final class SpecClassDescriptor extends AbstractTestDescriptor implements JavaSp
 		PendingSpecDescriptor specDescriptor = PendingSpecDescriptor.of(getUniqueId(), futureBehavior);
 		this.addChild(specDescriptor);
 	}
-
-	static final class DescribeDescriptor extends AbstractTestDescriptor {
-		public static DescribeDescriptor about(UniqueId parentId, String what) {
-			return new DescribeDescriptor(parentId.append("describe-block", what), what);
-		}
-
-		private DescribeDescriptor(UniqueId uniqueId, String displayName) {
-			super(uniqueId, displayName);
-		}
-
-		@Override
-		public Type getType() {
-			return Type.CONTAINER;
-		}
-	}
 }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
@@ -42,6 +42,11 @@ final class SpecClassDescriptor extends AbstractTestDescriptor implements JavaSp
 	public void describe(String what, BehaviorDeclaration declaration) {
 		DescribeDescriptor child = DescribeDescriptor.about(getUniqueId(), what);
 		this.addChild(child);
+
+		// I haven't added any notion of a stack to track the current context yet
+		// This will cause specs in the describe block to be children of this
+		// SpecClassDescriptor instead of DescribeDescriptor.
+//		declaration.declare();
 	}
 
 	@Override

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
@@ -3,6 +3,7 @@ package info.javaspec.engine;
 import info.javaspec.api.JavaSpec;
 import info.javaspec.api.SpecClass;
 import info.javaspec.api.Verification;
+import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 
@@ -59,5 +60,9 @@ final class SpecClassDescriptor extends AbstractTestDescriptor implements JavaSp
 	public void pending(String futureBehavior) {
 		PendingSpecDescriptor specDescriptor = PendingSpecDescriptor.of(getUniqueId(), futureBehavior);
 		this.addChild(specDescriptor);
+	}
+
+	private TestDescriptor currentContainer() {
+		return this;
 	}
 }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
@@ -41,7 +41,7 @@ final class SpecClassDescriptor extends AbstractTestDescriptor implements JavaSp
 
 	// Entry point into the discovery process
 	public void discover() {
-		this.container = this;
+		setCurrentContainer(this);
 		this.declaringInstance.declareSpecs(this);
 	}
 

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
@@ -11,9 +11,6 @@ import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 //Implements JavaSpec syntax on Jupiter.
 final class SpecClassDescriptor extends AbstractTestDescriptor implements JavaSpec {
 	private final SpecClass declaringInstance;
-
-	// TODO KDK: This will need to be a Stack, but how long can we get away with
-	// this? Maybe putting #it *after* #describe?
 	private TestDescriptor container;
 
 	public static SpecClassDescriptor of(UniqueId parentId, SpecClass declaringInstance) {

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
@@ -54,7 +54,8 @@ final class SpecClassDescriptor extends AbstractTestDescriptor implements JavaSp
 		// I haven't added any notion of a stack to track the current context yet
 		// This will cause specs in the describe block to be children of this
 		// SpecClassDescriptor instead of DescribeDescriptor.
-//		declaration.declare();
+		this.container = child;
+		declaration.declare();
 	}
 
 	@Override

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDescriptor.java
@@ -39,16 +39,35 @@ final class SpecClassDescriptor extends AbstractTestDescriptor implements JavaSp
 	}
 
 	@Override
+	public void describe(String what, BehaviorDeclaration declaration) {
+		DescribeDescriptor child = DescribeDescriptor.about(getUniqueId(), what);
+		this.addChild(child);
+	}
+
+	@Override
 	public void it(String behavior, Verification verification) {
 		SpecDescriptor specDescriptor = SpecDescriptor.of(getUniqueId(), behavior, verification);
-		specDescriptor.setParent(this);
 		this.addChild(specDescriptor);
 	}
 
 	@Override
 	public void pending(String futureBehavior) {
 		PendingSpecDescriptor specDescriptor = PendingSpecDescriptor.of(getUniqueId(), futureBehavior);
-		specDescriptor.setParent(this);
 		this.addChild(specDescriptor);
+	}
+
+	static final class DescribeDescriptor extends AbstractTestDescriptor {
+		public static DescribeDescriptor about(UniqueId parentId, String what) {
+			return new DescribeDescriptor(parentId.append("describe-block", what), what);
+		}
+
+		private DescribeDescriptor(UniqueId uniqueId, String displayName) {
+			super(uniqueId, displayName);
+		}
+
+		@Override
+		public Type getType() {
+			return Type.CONTAINER;
+		}
 	}
 }

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
@@ -9,6 +9,20 @@ import info.javaspec.api.SpecClass;
 public class AnonymousSpecClasses {
 	private AnonymousSpecClasses() { /* Static class */ }
 
+	public static Class<? extends SpecClass> specClassWithEmptyDescribeBlock() {
+		return specClassWithEmptyDescribeBlockInstance().getClass();
+	}
+
+	private static SpecClass specClassWithEmptyDescribeBlockInstance() {
+		return new SpecClass() {
+			@Override
+			public void declareSpecs(JavaSpec javaspec) {
+				javaspec.describe("something", () -> {
+					/* empty */ });
+			}
+		};
+	}
+
 	public static Class<?> notASpecClass() {
 		return new Object() {}.getClass();
 	}

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
@@ -17,8 +17,7 @@ public class AnonymousSpecClasses {
 		return new SpecClass() {
 			@Override
 			public void declareSpecs(JavaSpec javaspec) {
-				javaspec.describe("something", () -> {
-				});
+				javaspec.describe("something", () -> {});
 				javaspec.pending("spec");
 			}
 		};
@@ -47,7 +46,7 @@ public class AnonymousSpecClasses {
 		return new SpecClass() {
 			@Override
 			public void declareSpecs(JavaSpec javaspec) {
-				javaspec.describe("something", () -> { });
+				javaspec.describe("something", () -> {});
 			}
 		};
 	}

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
@@ -9,22 +9,6 @@ import info.javaspec.api.SpecClass;
 public class AnonymousSpecClasses {
 	private AnonymousSpecClasses() { /* Static class */ }
 
-	public static Class<? extends SpecClass> describeBlockWithOneSpec() {
-		return describeBlockWithOneSpecInstance().getClass();
-	}
-
-	private static SpecClass describeBlockWithOneSpecInstance() {
-		return new SpecClass() {
-			@Override
-			public void declareSpecs(JavaSpec javaspec) {
-				javaspec.describe("something", () -> {
-					javaspec.it("works", () -> {
-					});
-				});
-			}
-		};
-	}
-
 	public static Class<? extends SpecClass> describeThenSpec() {
 		return describeThenSpecInstance().getClass();
 	}
@@ -40,47 +24,58 @@ public class AnonymousSpecClasses {
 		};
 	}
 
-	public static Class<?> notASpecClass() {
-		return new Object() {}.getClass();
+	public static Class<? extends SpecClass> describeWithOneSpec() {
+		return describeWithOneSpecInstance().getClass();
 	}
 
-	public static Class<? extends SpecClass> nullDescribeBlock() {
-		return nullDescribeBlockInstance().getClass();
-	}
-
-	private static SpecClass nullDescribeBlockInstance() {
+	private static SpecClass describeWithOneSpecInstance() {
 		return new SpecClass() {
 			@Override
 			public void declareSpecs(JavaSpec javaspec) {
 				javaspec.describe("something", () -> {
-					/* empty */
+					javaspec.pending("works");
 				});
 			}
 		};
 	}
 
-	public static Class<? extends SpecClass> nullSpecClass() {
-		return nullSpecClassInstance().getClass();
+	public static Class<? extends SpecClass> emptyDescribe() {
+		return emptyDescribeInstance().getClass();
 	}
 
-	private static SpecClass nullSpecClassInstance() {
+	private static SpecClass emptyDescribeInstance() {
+		return new SpecClass() {
+			@Override
+			public void declareSpecs(JavaSpec javaspec) {
+				javaspec.describe("something", () -> { });
+			}
+		};
+	}
+
+	public static Class<? extends SpecClass> emptySpecClass() {
+		return emptySpecClassInstance().getClass();
+	}
+
+	private static SpecClass emptySpecClassInstance() {
 		return new SpecClass() {
 			@Override
 			public void declareSpecs(JavaSpec javaspec) { /* Do nothing */ }
 		};
 	}
 
-	public static Class<? extends SpecClass> oneSpecClass() {
-		return oneSpecClassInstance().getClass();
+	public static Class<?> notASpecClass() {
+		return new Object() {}.getClass();
 	}
 
-	private static SpecClass oneSpecClassInstance() {
+	public static Class<? extends SpecClass> oneSpec() {
+		return oneSpecInstance().getClass();
+	}
+
+	private static SpecClass oneSpecInstance() {
 		return new SpecClass() {
 			@Override
 			public void declareSpecs(JavaSpec javaspec) {
-				javaspec.it("one spec", () -> {
-					assertEquals(2, 1 + 1);
-				});
+				javaspec.it("one spec", () -> assertEquals(2, 1 + 1));
 			}
 		};
 	}
@@ -93,9 +88,7 @@ public class AnonymousSpecClasses {
 		return new SpecClass() {
 			@Override
 			public void declareSpecs(JavaSpec javaspec) {
-				javaspec.it("throws", () -> {
-					assertEquals(42, 41);
-				});
+				javaspec.it("throws", () -> assertEquals(42, 41));
 			}
 		};
 	}
@@ -115,11 +108,11 @@ public class AnonymousSpecClasses {
 		};
 	}
 
-	public static Class<? extends SpecClass> pendingSpecClass() {
-		return pendingSpecClassInstance().getClass();
+	public static Class<? extends SpecClass> pendingSpec() {
+		return pendingSpecInstance().getClass();
 	}
 
-	private static SpecClass pendingSpecClassInstance() {
+	private static SpecClass pendingSpecInstance() {
 		return new SpecClass() {
 			@Override
 			public void declareSpecs(JavaSpec javaspec) {

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
@@ -9,11 +9,31 @@ import info.javaspec.api.SpecClass;
 public class AnonymousSpecClasses {
 	private AnonymousSpecClasses() { /* Static class */ }
 
-	public static Class<? extends SpecClass> specClassWithEmptyDescribeBlock() {
-		return specClassWithEmptyDescribeBlockInstance().getClass();
+	public static Class<? extends SpecClass> describeBlockWithOneSpec() {
+		return describeBlockWithOneSpecInstance().getClass();
 	}
 
-	private static SpecClass specClassWithEmptyDescribeBlockInstance() {
+	private static SpecClass describeBlockWithOneSpecInstance() {
+		return new SpecClass() {
+			@Override
+			public void declareSpecs(JavaSpec javaspec) {
+				javaspec.describe("something", () -> {
+					javaspec.it("works", () -> {
+					});
+				});
+			}
+		};
+	}
+
+	public static Class<?> notASpecClass() {
+		return new Object() {}.getClass();
+	}
+
+	public static Class<? extends SpecClass> nullDescribeBlock() {
+		return nullDescribeBlockInstance().getClass();
+	}
+
+	private static SpecClass nullDescribeBlockInstance() {
 		return new SpecClass() {
 			@Override
 			public void declareSpecs(JavaSpec javaspec) {
@@ -22,10 +42,6 @@ public class AnonymousSpecClasses {
 				});
 			}
 		};
-	}
-
-	public static Class<?> notASpecClass() {
-		return new Object() {}.getClass();
 	}
 
 	public static Class<? extends SpecClass> nullSpecClass() {

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
@@ -25,6 +25,21 @@ public class AnonymousSpecClasses {
 		};
 	}
 
+	public static Class<? extends SpecClass> describeThenSpec() {
+		return describeThenSpecInstance().getClass();
+	}
+
+	private static SpecClass describeThenSpecInstance() {
+		return new SpecClass() {
+			@Override
+			public void declareSpecs(JavaSpec javaspec) {
+				javaspec.describe("something", () -> {
+				});
+				javaspec.pending("spec");
+			}
+		};
+	}
+
 	public static Class<?> notASpecClass() {
 		return new Object() {}.getClass();
 	}

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
@@ -18,7 +18,8 @@ public class AnonymousSpecClasses {
 			@Override
 			public void declareSpecs(JavaSpec javaspec) {
 				javaspec.describe("something", () -> {
-					/* empty */ });
+					/* empty */
+				});
 			}
 		};
 	}

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -89,7 +89,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 		javaspec.it("#discover discovers a describe block", () -> {
 			JavaSpecEngine subject = new JavaSpecEngine();
-			Class<?> describeSpecClass = specClassWithEmptyDescribeBlock();
+			Class<?> describeSpecClass = nullDescribeBlock();
 			TestDescriptor returned = subject
 				.discover(classEngineDiscoveryRequest(describeSpecClass), UniqueId.forEngine(subject.getId()));
 
@@ -107,6 +107,22 @@ public class JavaSpecEngineTest implements SpecClass {
 			assertTrue(describeDescriptor.isContainer());
 			assertFalse(describeDescriptor.isRoot());
 			assertFalse(describeDescriptor.isTest());
+		});
+
+		javaspec.it("#discover discovers a describe block with a spec in it", () -> {
+			JavaSpecEngine subject = new JavaSpecEngine();
+			TestDescriptor returned = subject.discover(
+				classEngineDiscoveryRequest(describeBlockWithOneSpec()),
+				UniqueId.forEngine(subject.getId())
+			);
+
+			TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
+			TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
+			assertEquals(1, describeDescriptor.getChildren().size());
+
+			TestDescriptor specDescriptor = describeDescriptor.getChildren().iterator().next();
+			assertEquals("works", specDescriptor.getDisplayName());
+			assertTrue(specDescriptor.isTest());
 		});
 
 		javaspec.it("#discover discovers a pending spec", () -> {

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -109,23 +109,23 @@ public class JavaSpecEngineTest implements SpecClass {
 			assertFalse(describeDescriptor.isTest());
 		});
 
-//		javaspec.it("#discover discovers a describe block with a spec in it", () -> {
-//			JavaSpecEngine subject = new JavaSpecEngine();
-//			TestDescriptor returned = subject.discover(
-//				classEngineDiscoveryRequest(describeBlockWithOneSpec()),
-//				UniqueId.forEngine(subject.getId())
-//			);
-//
-//			TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
-//			assertEquals(1, specClassDescriptor.getChildren().size());
-//
-//			TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
-//			assertEquals(1, describeDescriptor.getChildren().size());
-//
-//			TestDescriptor specDescriptor = describeDescriptor.getChildren().iterator().next();
-//			assertEquals("works", specDescriptor.getDisplayName());
-//			assertTrue(specDescriptor.isTest());
-//		});
+		javaspec.it("#discover discovers a describe block with a spec in it", () -> {
+			JavaSpecEngine subject = new JavaSpecEngine();
+			TestDescriptor returned = subject.discover(
+				classEngineDiscoveryRequest(describeBlockWithOneSpec()),
+				UniqueId.forEngine(subject.getId())
+			);
+
+			TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
+			assertEquals(1, specClassDescriptor.getChildren().size());
+
+			TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
+			assertEquals(1, describeDescriptor.getChildren().size());
+
+			TestDescriptor specDescriptor = describeDescriptor.getChildren().iterator().next();
+			assertEquals("works", specDescriptor.getDisplayName());
+			assertTrue(specDescriptor.isTest());
+		});
 
 		javaspec.it("#discover discovers a pending spec", () -> {
 			JavaSpecEngine subject = new JavaSpecEngine();

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -33,244 +33,248 @@ public class JavaSpecEngineTest implements SpecClass {
 			EngineTestKit.engine("javaspec-engine").selectors(selectClass(nullSpecClass())).execute();
 		});
 
-		javaspec.it("#discover reports to a provided EngineDiscoveryRequestListener", () -> {
-			MockEngineDiscoveryRequestListener listener = new MockEngineDiscoveryRequestListener();
-			JavaSpecEngine subject = new JavaSpecEngine(() -> Optional.of(listener));
+		javaspec.describe("#discover", () -> {
+			javaspec.it("#discover reports to a provided EngineDiscoveryRequestListener", () -> {
+				MockEngineDiscoveryRequestListener listener = new MockEngineDiscoveryRequestListener();
+				JavaSpecEngine subject = new JavaSpecEngine(() -> Optional.of(listener));
 
-			subject.discover(nullEngineDiscoveryRequest(), UniqueId.forEngine(subject.getId()));
-			listener.onDiscoverExpected();
-		});
+				subject.discover(nullEngineDiscoveryRequest(), UniqueId.forEngine(subject.getId()));
+				listener.onDiscoverExpected();
+			});
 
-		javaspec.it("#discover returns a top-level container for itself, using the given UniqueId", () -> {
-			JavaSpecEngine subject = new JavaSpecEngine();
-			UniqueId engineId = UniqueId.forEngine(subject.getId());
+			javaspec.it("#discover returns a top-level container for itself, using the given UniqueId", () -> {
+				JavaSpecEngine subject = new JavaSpecEngine();
+				UniqueId engineId = UniqueId.forEngine(subject.getId());
 
-			TestDescriptor returned = subject.discover(nullEngineDiscoveryRequest(), engineId);
-			assertEquals(engineId, returned.getUniqueId());
-			assertEquals("JavaSpec", returned.getDisplayName());
-			assertEquals(Optional.empty(), returned.getParent());
-			assertTrue(returned.isContainer());
-			assertTrue(returned.isRoot());
-		});
+				TestDescriptor returned = subject.discover(nullEngineDiscoveryRequest(), engineId);
+				assertEquals(engineId, returned.getUniqueId());
+				assertEquals("JavaSpec", returned.getDisplayName());
+				assertEquals(Optional.empty(), returned.getParent());
+				assertTrue(returned.isContainer());
+				assertTrue(returned.isRoot());
+			});
 
-		javaspec.it("#discover discovers no containers or tests, given no selectors", () -> {
-			JavaSpecEngine subject = new JavaSpecEngine();
+			javaspec.it("#discover discovers no containers or tests, given no selectors", () -> {
+				JavaSpecEngine subject = new JavaSpecEngine();
 
-			TestDescriptor returned = subject.discover(nullEngineDiscoveryRequest(), UniqueId.forEngine(subject.getId()));
-			assertEquals(Collections.emptySet(), returned.getChildren());
-			assertFalse(returned.isTest());
-		});
+				TestDescriptor returned = subject.discover(nullEngineDiscoveryRequest(), UniqueId.forEngine(subject.getId()));
+				assertEquals(Collections.emptySet(), returned.getChildren());
+				assertFalse(returned.isTest());
+			});
 
-		javaspec.it("#discover ignores selectors for classes that are not SpecClass", () -> {
-			JavaSpecEngine subject = new JavaSpecEngine();
-			TestDescriptor returned = subject
-				.discover(classEngineDiscoveryRequest(notASpecClass()), UniqueId.forEngine(subject.getId()));
-			assertEquals(Collections.emptySet(), returned.getChildren());
-		});
+			javaspec.it("#discover ignores selectors for classes that are not SpecClass", () -> {
+				JavaSpecEngine subject = new JavaSpecEngine();
+				TestDescriptor returned = subject
+					.discover(classEngineDiscoveryRequest(notASpecClass()), UniqueId.forEngine(subject.getId()));
+				assertEquals(Collections.emptySet(), returned.getChildren());
+			});
 
-		javaspec.it("#discover discovers a container for each selected spec class", () -> {
-			JavaSpecEngine subject = new JavaSpecEngine();
-			Class<?> nullSpecClass = nullSpecClass();
-			TestDescriptor returned = subject
-				.discover(classEngineDiscoveryRequest(nullSpecClass), UniqueId.forEngine(subject.getId()));
+			javaspec.it("#discover discovers a container for each selected spec class", () -> {
+				JavaSpecEngine subject = new JavaSpecEngine();
+				Class<?> nullSpecClass = nullSpecClass();
+				TestDescriptor returned = subject
+					.discover(classEngineDiscoveryRequest(nullSpecClass), UniqueId.forEngine(subject.getId()));
 
-			List<TestDescriptor> specClassDescriptors = new ArrayList<>(returned.getChildren());
-			assertEquals(1, returned.getChildren().size());
+				List<TestDescriptor> specClassDescriptors = new ArrayList<>(returned.getChildren());
+				assertEquals(1, returned.getChildren().size());
 
-			TestDescriptor onlyChild = specClassDescriptors.get(0);
-			UniqueId.Segment idSegment = onlyChild.getUniqueId().getLastSegment();
-			assertEquals("class", idSegment.getType());
-			assertEquals(nullSpecClass.getName(), idSegment.getValue());
+				TestDescriptor onlyChild = specClassDescriptors.get(0);
+				UniqueId.Segment idSegment = onlyChild.getUniqueId().getLastSegment();
+				assertEquals("class", idSegment.getType());
+				assertEquals(nullSpecClass.getName(), idSegment.getValue());
 
-			assertEquals(nullSpecClass.getName(), onlyChild.getDisplayName());
-			assertEquals(returned, onlyChild.getParent().orElseThrow());
-			assertTrue(onlyChild.isContainer());
-			assertFalse(onlyChild.isRoot());
-			assertFalse(onlyChild.isTest());
-		});
+				assertEquals(nullSpecClass.getName(), onlyChild.getDisplayName());
+				assertEquals(returned, onlyChild.getParent().orElseThrow());
+				assertTrue(onlyChild.isContainer());
+				assertFalse(onlyChild.isRoot());
+				assertFalse(onlyChild.isTest());
+			});
 
-		javaspec.it("#discover discovers a describe block", () -> {
-			JavaSpecEngine subject = new JavaSpecEngine();
-			Class<?> describeSpecClass = nullDescribeBlock();
-			TestDescriptor returned = subject
-				.discover(classEngineDiscoveryRequest(describeSpecClass), UniqueId.forEngine(subject.getId()));
+			javaspec.it("#discover discovers a describe block", () -> {
+				JavaSpecEngine subject = new JavaSpecEngine();
+				Class<?> describeSpecClass = nullDescribeBlock();
+				TestDescriptor returned = subject
+					.discover(classEngineDiscoveryRequest(describeSpecClass), UniqueId.forEngine(subject.getId()));
 
-			assertEquals(1, returned.getChildren().size());
-			TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
+				assertEquals(1, returned.getChildren().size());
+				TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
 
-			assertEquals(1, specClassDescriptor.getChildren().size());
-			TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
-			UniqueId.Segment idSegment = describeDescriptor.getUniqueId().getLastSegment();
-			assertEquals("describe-block", idSegment.getType());
-			assertEquals("something", idSegment.getValue());
+				assertEquals(1, specClassDescriptor.getChildren().size());
+				TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
+				UniqueId.Segment idSegment = describeDescriptor.getUniqueId().getLastSegment();
+				assertEquals("describe-block", idSegment.getType());
+				assertEquals("something", idSegment.getValue());
 
-			assertEquals("something", describeDescriptor.getDisplayName());
-			assertEquals(specClassDescriptor, describeDescriptor.getParent().orElseThrow());
-			assertTrue(describeDescriptor.isContainer());
-			assertFalse(describeDescriptor.isRoot());
-			assertFalse(describeDescriptor.isTest());
-		});
+				assertEquals("something", describeDescriptor.getDisplayName());
+				assertEquals(specClassDescriptor, describeDescriptor.getParent().orElseThrow());
+				assertTrue(describeDescriptor.isContainer());
+				assertFalse(describeDescriptor.isRoot());
+				assertFalse(describeDescriptor.isTest());
+			});
 
-		javaspec.it("#discover discovers a describe block with a spec in it", () -> {
-			JavaSpecEngine subject = new JavaSpecEngine();
-			TestDescriptor returned = subject.discover(
-				classEngineDiscoveryRequest(describeBlockWithOneSpec()),
-				UniqueId.forEngine(subject.getId())
-			);
-
-			TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
-			assertEquals(1, specClassDescriptor.getChildren().size());
-
-			TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
-			assertEquals(1, describeDescriptor.getChildren().size());
-
-			TestDescriptor specDescriptor = describeDescriptor.getChildren().iterator().next();
-			assertEquals("works", specDescriptor.getDisplayName());
-			assertTrue(specDescriptor.isTest());
-		});
-
-		javaspec.it("#discover discovers a pending spec", () -> {
-			JavaSpecEngine subject = new JavaSpecEngine();
-			TestDescriptor returned = subject
-				.discover(classEngineDiscoveryRequest(pendingSpecClass()), UniqueId.forEngine(subject.getId()));
-
-			TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
-			assertEquals(1, specClassDescriptor.getChildren().size());
-
-			TestDescriptor specDescriptor = specClassDescriptor.getChildren().iterator().next();
-			UniqueId.Segment idSegment = specDescriptor.getUniqueId().getLastSegment();
-			assertEquals("test", idSegment.getType());
-			assertEquals("pending spec", idSegment.getValue());
-		});
-
-		javaspec.it("#discover discovers a test for each spec in a spec class", () -> {
-			JavaSpecEngine subject = new JavaSpecEngine();
-			TestDescriptor returned = subject
-				.discover(classEngineDiscoveryRequest(oneSpecClass()), UniqueId.forEngine(subject.getId()));
-
-			TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
-			assertEquals(1, specClassDescriptor.getChildren().size());
-
-			TestDescriptor specDescriptor = specClassDescriptor.getChildren().iterator().next();
-			UniqueId.Segment idSegment = specDescriptor.getUniqueId().getLastSegment();
-			assertEquals("test", idSegment.getType());
-			assertEquals("one spec", idSegment.getValue());
-
-			assertEquals(specClassDescriptor, specDescriptor.getParent().orElseThrow());
-			assertFalse(specDescriptor.isContainer());
-			assertFalse(specDescriptor.isRoot());
-			assertTrue(specDescriptor.isTest());
-		});
-
-		javaspec.it("#discover discovers specs declared after a describe block in the same level of nesting", () -> {
-			JavaSpecEngine subject = new JavaSpecEngine();
-			TestDescriptor returned = subject.discover(
-				classEngineDiscoveryRequest(AnonymousSpecClasses.describeThenSpec()),
-				UniqueId.forEngine(subject.getId())
-			);
-
-			TestDescriptor specClass = returned.getChildren().iterator().next();
-			List<String> displayNames = specClass.getChildren().stream()
-				.map(TestDescriptor::getDisplayName)
-				.collect(Collectors.toList());
-			assertEquals(Lists.newArrayList("something", "spec"), displayNames);
-		});
-
-		javaspec.pending("#discover discovers two describe blocks, side by side");
-
-		javaspec.it("#execute reports execution events for the engine", () -> {
-			EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-				.selectors(nullDiscoverySelector())
-				.execute();
-			results.containerEvents()
-				.assertEventsMatchExactly(event(engine(), started()), event(engine(), finishedSuccessfully()));
-		});
-
-		javaspec.it("#execute skips spec class containers that don't have any specs in them", () -> {
-			EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-				.selectors(selectClass(nullSpecClass()))
-				.execute();
-			results.containerEvents()
-				.assertEventsMatchExactly(event(engine(), started()), event(engine(), finishedSuccessfully()));
-		});
-
-		javaspec.it("#execute reports execution events for spec class containers", () -> {
-			EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-				.selectors(selectClass(oneSpecClass()))
-				.execute();
-
-			results.containerEvents()
-				.assertEventsMatchExactly(
-					event(engine(), started()),
-					event(container(), started()),
-					event(container(), finishedSuccessfully()),
-					event(engine(), finishedSuccessfully())
+			javaspec.it("#discover discovers a describe block with a spec in it", () -> {
+				JavaSpecEngine subject = new JavaSpecEngine();
+				TestDescriptor returned = subject.discover(
+					classEngineDiscoveryRequest(describeBlockWithOneSpec()),
+					UniqueId.forEngine(subject.getId())
 				);
-		});
 
-		javaspec.it("#execute reports start and skipped events for pending specs", () -> {
-			EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-				.selectors(selectClass(pendingSpecClass()))
-				.execute();
+				TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
+				assertEquals(1, specClassDescriptor.getChildren().size());
 
-			results.allEvents()
-				.assertEventsMatchLooselyInOrder(
-					event(test(), started()),
-					event(test(), skippedWithReason("pending"))
+				TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
+				assertEquals(1, describeDescriptor.getChildren().size());
+
+				TestDescriptor specDescriptor = describeDescriptor.getChildren().iterator().next();
+				assertEquals("works", specDescriptor.getDisplayName());
+				assertTrue(specDescriptor.isTest());
+			});
+
+			javaspec.it("#discover discovers a pending spec", () -> {
+				JavaSpecEngine subject = new JavaSpecEngine();
+				TestDescriptor returned = subject
+					.discover(classEngineDiscoveryRequest(pendingSpecClass()), UniqueId.forEngine(subject.getId()));
+
+				TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
+				assertEquals(1, specClassDescriptor.getChildren().size());
+
+				TestDescriptor specDescriptor = specClassDescriptor.getChildren().iterator().next();
+				UniqueId.Segment idSegment = specDescriptor.getUniqueId().getLastSegment();
+				assertEquals("test", idSegment.getType());
+				assertEquals("pending spec", idSegment.getValue());
+			});
+
+			javaspec.it("#discover discovers a test for each spec in a spec class", () -> {
+				JavaSpecEngine subject = new JavaSpecEngine();
+				TestDescriptor returned = subject
+					.discover(classEngineDiscoveryRequest(oneSpecClass()), UniqueId.forEngine(subject.getId()));
+
+				TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
+				assertEquals(1, specClassDescriptor.getChildren().size());
+
+				TestDescriptor specDescriptor = specClassDescriptor.getChildren().iterator().next();
+				UniqueId.Segment idSegment = specDescriptor.getUniqueId().getLastSegment();
+				assertEquals("test", idSegment.getType());
+				assertEquals("one spec", idSegment.getValue());
+
+				assertEquals(specClassDescriptor, specDescriptor.getParent().orElseThrow());
+				assertFalse(specDescriptor.isContainer());
+				assertFalse(specDescriptor.isRoot());
+				assertTrue(specDescriptor.isTest());
+			});
+
+			javaspec.it("#discover discovers specs declared after a describe block in the same level of nesting", () -> {
+				JavaSpecEngine subject = new JavaSpecEngine();
+				TestDescriptor returned = subject.discover(
+					classEngineDiscoveryRequest(AnonymousSpecClasses.describeThenSpec()),
+					UniqueId.forEngine(subject.getId())
 				);
+
+				TestDescriptor specClass = returned.getChildren().iterator().next();
+				List<String> displayNames = specClass.getChildren().stream()
+					.map(TestDescriptor::getDisplayName)
+					.collect(Collectors.toList());
+				assertEquals(Lists.newArrayList("something", "spec"), displayNames);
+			});
 		});
 
-		javaspec.it("#execute reports start and successful finish events for passing specs", () -> {
-			EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-				.selectors(selectClass(oneSpecClass()))
-				.execute();
+		javaspec.describe("#execute", () -> {
+			javaspec.it("#execute reports execution events for the engine", () -> {
+				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
+					.selectors(nullDiscoverySelector())
+					.execute();
+				results.containerEvents()
+					.assertEventsMatchExactly(event(engine(), started()), event(engine(), finishedSuccessfully()));
+			});
 
-			results.allEvents()
-				.assertEventsMatchLooselyInOrder(
-					event(container(), started()),
-					event(test(), started()),
-					event(test(), finishedSuccessfully()),
-					event(container(), finishedSuccessfully())
-				);
+			javaspec.it("#execute skips spec class containers that don't have any specs in them", () -> {
+				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
+					.selectors(selectClass(nullSpecClass()))
+					.execute();
+				results.containerEvents()
+					.assertEventsMatchExactly(event(engine(), started()), event(engine(), finishedSuccessfully()));
+			});
+
+			javaspec.it("#execute reports execution events for spec class containers", () -> {
+				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
+					.selectors(selectClass(oneSpecClass()))
+					.execute();
+
+				results.containerEvents()
+					.assertEventsMatchExactly(
+						event(engine(), started()),
+						event(container(), started()),
+						event(container(), finishedSuccessfully()),
+						event(engine(), finishedSuccessfully())
+					);
+			});
+
+			javaspec.it("#execute reports start and skipped events for pending specs", () -> {
+				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
+					.selectors(selectClass(pendingSpecClass()))
+					.execute();
+
+				results.allEvents()
+					.assertEventsMatchLooselyInOrder(
+						event(test(), started()),
+						event(test(), skippedWithReason("pending"))
+					);
+			});
+
+			javaspec.it("#execute reports start and successful finish events for passing specs", () -> {
+				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
+					.selectors(selectClass(oneSpecClass()))
+					.execute();
+
+				results.allEvents()
+					.assertEventsMatchLooselyInOrder(
+						event(container(), started()),
+						event(test(), started()),
+						event(test(), finishedSuccessfully()),
+						event(container(), finishedSuccessfully())
+					);
+			});
+
+			javaspec.it("#execute reports start and failed finish events for failing specs", () -> {
+				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
+					.selectors(selectClass(oneSpecThrowingRuntimeException()))
+					.execute();
+
+				results.allEvents()
+					.assertEventsMatchLooselyInOrder(
+						event(container(), started()),
+						event(test(), started()),
+						event(
+							test(),
+							finishedWithFailure(new Condition<>(RuntimeException.class::isInstance, "RuntimeException"))
+						),
+						event(container(), finishedSuccessfully())
+					);
+			});
+
+			javaspec.it("#execute catches specs that fail by throwing AssertionError", () -> {
+				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
+					.selectors(selectClass(oneSpecThrowingAssertionError()))
+					.execute();
+
+				results.allEvents()
+					.assertEventsMatchLooselyInOrder(
+						event(container(), started()),
+						event(test(), started()),
+						event(
+							test(),
+							finishedWithFailure(new Condition<>(AssertionError.class::isInstance, "AssertionError"))
+						),
+						event(container(), finishedSuccessfully())
+					);
+			});
 		});
 
-		javaspec.it("#execute reports start and failed finish events for failing specs", () -> {
-			EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-				.selectors(selectClass(oneSpecThrowingRuntimeException()))
-				.execute();
-
-			results.allEvents()
-				.assertEventsMatchLooselyInOrder(
-					event(container(), started()),
-					event(test(), started()),
-					event(
-						test(),
-						finishedWithFailure(new Condition<Throwable>(t -> RuntimeException.class.isInstance(t), "RuntimeException"))
-					),
-					event(container(), finishedSuccessfully())
-				);
-		});
-
-		javaspec.it("#execute catches specs that fail by throwing AssertionError", () -> {
-			EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-				.selectors(selectClass(oneSpecThrowingAssertionError()))
-				.execute();
-
-			results.allEvents()
-				.assertEventsMatchLooselyInOrder(
-					event(container(), started()),
-					event(test(), started()),
-					event(
-						test(),
-						finishedWithFailure(new Condition<Throwable>(t -> AssertionError.class.isInstance(t), "AssertionError"))
-					),
-					event(container(), finishedSuccessfully())
-				);
-		});
-
-		javaspec.it("#getId returns a unique ID", () -> {
-			TestEngine subject = new JavaSpecEngine();
-			assertEquals("javaspec-engine", subject.getId());
+		javaspec.describe("#getId", () -> {
+			javaspec.it("#getId returns a unique ID", () -> {
+				TestEngine subject = new JavaSpecEngine();
+				assertEquals("javaspec-engine", subject.getId());
+			});
 		});
 	}
 

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -34,7 +34,7 @@ public class JavaSpecEngineTest implements SpecClass {
 		});
 
 		javaspec.describe("#discover", () -> {
-			javaspec.it("#discover reports to a provided EngineDiscoveryRequestListener", () -> {
+			javaspec.it("reports to a provided EngineDiscoveryRequestListener", () -> {
 				MockEngineDiscoveryRequestListener listener = new MockEngineDiscoveryRequestListener();
 				JavaSpecEngine subject = new JavaSpecEngine(() -> Optional.of(listener));
 
@@ -42,7 +42,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				listener.onDiscoverExpected();
 			});
 
-			javaspec.it("#discover returns a top-level container for itself, using the given UniqueId", () -> {
+			javaspec.it("returns a top-level container for itself, using the given UniqueId", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
 				UniqueId engineId = UniqueId.forEngine(subject.getId());
 
@@ -54,7 +54,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertTrue(returned.isRoot());
 			});
 
-			javaspec.it("#discover discovers no containers or tests, given no selectors", () -> {
+			javaspec.it("discovers no containers or tests, given no selectors", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
 
 				TestDescriptor returned = subject.discover(nullEngineDiscoveryRequest(), UniqueId.forEngine(subject.getId()));
@@ -62,14 +62,14 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertFalse(returned.isTest());
 			});
 
-			javaspec.it("#discover ignores selectors for classes that are not SpecClass", () -> {
+			javaspec.it("ignores selectors for classes that are not SpecClass", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
 				TestDescriptor returned = subject
 					.discover(classEngineDiscoveryRequest(notASpecClass()), UniqueId.forEngine(subject.getId()));
 				assertEquals(Collections.emptySet(), returned.getChildren());
 			});
 
-			javaspec.it("#discover discovers a container for each selected spec class", () -> {
+			javaspec.it("discovers a container for each selected spec class", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
 				Class<?> nullSpecClass = nullSpecClass();
 				TestDescriptor returned = subject
@@ -90,7 +90,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertFalse(onlyChild.isTest());
 			});
 
-			javaspec.it("#discover discovers a describe block", () -> {
+			javaspec.it("discovers a describe block", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
 				Class<?> describeSpecClass = nullDescribeBlock();
 				TestDescriptor returned = subject
@@ -112,7 +112,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertFalse(describeDescriptor.isTest());
 			});
 
-			javaspec.it("#discover discovers a describe block with a spec in it", () -> {
+			javaspec.it("discovers a describe block with a spec in it", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
 				TestDescriptor returned = subject.discover(
 					classEngineDiscoveryRequest(describeBlockWithOneSpec()),
@@ -130,7 +130,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertTrue(specDescriptor.isTest());
 			});
 
-			javaspec.it("#discover discovers a pending spec", () -> {
+			javaspec.it("discovers a pending spec", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
 				TestDescriptor returned = subject
 					.discover(classEngineDiscoveryRequest(pendingSpecClass()), UniqueId.forEngine(subject.getId()));
@@ -144,7 +144,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertEquals("pending spec", idSegment.getValue());
 			});
 
-			javaspec.it("#discover discovers a test for each spec in a spec class", () -> {
+			javaspec.it("discovers a test for each spec in a spec class", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
 				TestDescriptor returned = subject
 					.discover(classEngineDiscoveryRequest(oneSpecClass()), UniqueId.forEngine(subject.getId()));
@@ -163,7 +163,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertTrue(specDescriptor.isTest());
 			});
 
-			javaspec.it("#discover discovers specs declared after a describe block in the same level of nesting", () -> {
+			javaspec.it("discovers specs declared after a describe block in the same level of nesting", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
 				TestDescriptor returned = subject.discover(
 					classEngineDiscoveryRequest(AnonymousSpecClasses.describeThenSpec()),
@@ -179,7 +179,7 @@ public class JavaSpecEngineTest implements SpecClass {
 		});
 
 		javaspec.describe("#execute", () -> {
-			javaspec.it("#execute reports execution events for the engine", () -> {
+			javaspec.it("reports execution events for the engine", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
 					.selectors(nullDiscoverySelector())
 					.execute();
@@ -187,7 +187,7 @@ public class JavaSpecEngineTest implements SpecClass {
 					.assertEventsMatchExactly(event(engine(), started()), event(engine(), finishedSuccessfully()));
 			});
 
-			javaspec.it("#execute skips spec class containers that don't have any specs in them", () -> {
+			javaspec.it("skips spec class containers that don't have any specs in them", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
 					.selectors(selectClass(nullSpecClass()))
 					.execute();
@@ -195,7 +195,7 @@ public class JavaSpecEngineTest implements SpecClass {
 					.assertEventsMatchExactly(event(engine(), started()), event(engine(), finishedSuccessfully()));
 			});
 
-			javaspec.it("#execute reports execution events for spec class containers", () -> {
+			javaspec.it("reports execution events for spec class containers", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
 					.selectors(selectClass(oneSpecClass()))
 					.execute();
@@ -209,7 +209,7 @@ public class JavaSpecEngineTest implements SpecClass {
 					);
 			});
 
-			javaspec.it("#execute reports start and skipped events for pending specs", () -> {
+			javaspec.it("reports start and skipped events for pending specs", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
 					.selectors(selectClass(pendingSpecClass()))
 					.execute();
@@ -221,7 +221,7 @@ public class JavaSpecEngineTest implements SpecClass {
 					);
 			});
 
-			javaspec.it("#execute reports start and successful finish events for passing specs", () -> {
+			javaspec.it("reports start and successful finish events for passing specs", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
 					.selectors(selectClass(oneSpecClass()))
 					.execute();
@@ -235,7 +235,7 @@ public class JavaSpecEngineTest implements SpecClass {
 					);
 			});
 
-			javaspec.it("#execute reports start and failed finish events for failing specs", () -> {
+			javaspec.it("reports start and failed finish events for failing specs", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
 					.selectors(selectClass(oneSpecThrowingRuntimeException()))
 					.execute();
@@ -252,7 +252,7 @@ public class JavaSpecEngineTest implements SpecClass {
 					);
 			});
 
-			javaspec.it("#execute catches specs that fail by throwing AssertionError", () -> {
+			javaspec.it("catches specs that fail by throwing AssertionError", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
 					.selectors(selectClass(oneSpecThrowingAssertionError()))
 					.execute();
@@ -271,7 +271,7 @@ public class JavaSpecEngineTest implements SpecClass {
 		});
 
 		javaspec.describe("#getId", () -> {
-			javaspec.it("#getId returns a unique ID", () -> {
+			javaspec.it("returns a unique ID", () -> {
 				TestEngine subject = new JavaSpecEngine();
 				assertEquals("javaspec-engine", subject.getId());
 			});

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -1,6 +1,5 @@
 package info.javaspec.engine;
 
-import static info.javaspec.engine.AnonymousSpecClasses.*;
 import static info.javaspec.engine.DiscoverySelectorFactory.nullDiscoverySelector;
 import static info.javaspec.engine.EngineDiscoveryRequestFactory.classEngineDiscoveryRequest;
 import static info.javaspec.engine.EngineDiscoveryRequestFactory.nullEngineDiscoveryRequest;
@@ -30,7 +29,9 @@ public class JavaSpecEngineTest implements SpecClass {
 	@Override
 	public void declareSpecs(JavaSpec javaspec) {
 		javaspec.it("can be loaded with ServiceLoader and located by ID", () -> {
-			EngineTestKit.engine("javaspec-engine").selectors(selectClass(emptySpecClass())).execute();
+			EngineTestKit.engine("javaspec-engine")
+				.selectors(selectClass(AnonymousSpecClasses.emptySpecClass()))
+				.execute();
 		});
 
 		javaspec.describe("#discover", () -> {
@@ -64,16 +65,20 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("ignores selectors for classes that are not SpecClass", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
-				TestDescriptor returned = subject
-					.discover(classEngineDiscoveryRequest(notASpecClass()), UniqueId.forEngine(subject.getId()));
+				TestDescriptor returned = subject.discover(
+					classEngineDiscoveryRequest(AnonymousSpecClasses.notASpecClass()),
+					UniqueId.forEngine(subject.getId())
+				);
 				assertEquals(Collections.emptySet(), returned.getChildren());
 			});
 
 			javaspec.it("discovers a container for each selected spec class", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
-				Class<?> nullSpecClass = emptySpecClass();
-				TestDescriptor returned = subject
-					.discover(classEngineDiscoveryRequest(nullSpecClass), UniqueId.forEngine(subject.getId()));
+				Class<?> nullSpecClass = AnonymousSpecClasses.emptySpecClass();
+				TestDescriptor returned = subject.discover(
+					classEngineDiscoveryRequest(nullSpecClass),
+					UniqueId.forEngine(subject.getId())
+				);
 
 				List<TestDescriptor> specClassDescriptors = new ArrayList<>(returned.getChildren());
 				assertEquals(1, returned.getChildren().size());
@@ -92,9 +97,10 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("discovers a describe block", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
-				Class<?> describeSpecClass = emptyDescribe();
-				TestDescriptor returned = subject
-					.discover(classEngineDiscoveryRequest(describeSpecClass), UniqueId.forEngine(subject.getId()));
+				TestDescriptor returned = subject.discover(
+					classEngineDiscoveryRequest(AnonymousSpecClasses.emptyDescribe()),
+					UniqueId.forEngine(subject.getId())
+				);
 
 				assertEquals(1, returned.getChildren().size());
 				TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
@@ -115,7 +121,7 @@ public class JavaSpecEngineTest implements SpecClass {
 			javaspec.it("discovers a describe block with a spec in it", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
 				TestDescriptor returned = subject.discover(
-					classEngineDiscoveryRequest(describeWithOneSpec()),
+					classEngineDiscoveryRequest(AnonymousSpecClasses.describeWithOneSpec()),
 					UniqueId.forEngine(subject.getId())
 				);
 
@@ -132,8 +138,10 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("discovers a pending spec", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
-				TestDescriptor returned = subject
-					.discover(classEngineDiscoveryRequest(pendingSpec()), UniqueId.forEngine(subject.getId()));
+				TestDescriptor returned = subject.discover(
+					classEngineDiscoveryRequest(AnonymousSpecClasses.pendingSpec()),
+					UniqueId.forEngine(subject.getId())
+				);
 
 				TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
 				assertEquals(1, specClassDescriptor.getChildren().size());
@@ -146,8 +154,10 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("discovers a test for each spec in a spec class", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
-				TestDescriptor returned = subject
-					.discover(classEngineDiscoveryRequest(oneSpec()), UniqueId.forEngine(subject.getId()));
+				TestDescriptor returned = subject.discover(
+					classEngineDiscoveryRequest(AnonymousSpecClasses.oneSpec()),
+					UniqueId.forEngine(subject.getId())
+				);
 
 				TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
 				assertEquals(1, specClassDescriptor.getChildren().size());
@@ -189,7 +199,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("skips spec class containers that don't have any specs in them", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-					.selectors(selectClass(emptySpecClass()))
+					.selectors(selectClass(AnonymousSpecClasses.emptySpecClass()))
 					.execute();
 				results.containerEvents()
 					.assertEventsMatchExactly(event(engine(), started()), event(engine(), finishedSuccessfully()));
@@ -197,7 +207,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("reports execution events for spec class containers", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-					.selectors(selectClass(oneSpec()))
+					.selectors(selectClass(AnonymousSpecClasses.oneSpec()))
 					.execute();
 
 				results.containerEvents()
@@ -211,7 +221,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("reports start and skipped events for pending specs", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-					.selectors(selectClass(pendingSpec()))
+					.selectors(selectClass(AnonymousSpecClasses.pendingSpec()))
 					.execute();
 
 				results.allEvents()
@@ -223,7 +233,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("reports start and successful finish events for passing specs", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-					.selectors(selectClass(oneSpec()))
+					.selectors(selectClass(AnonymousSpecClasses.oneSpec()))
 					.execute();
 
 				results.allEvents()
@@ -237,7 +247,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("reports start and failed finish events for failing specs", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-					.selectors(selectClass(oneSpecThrowingRuntimeException()))
+					.selectors(selectClass(AnonymousSpecClasses.oneSpecThrowingRuntimeException()))
 					.execute();
 
 				results.allEvents()
@@ -254,7 +264,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("catches specs that fail by throwing AssertionError", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-					.selectors(selectClass(oneSpecThrowingAssertionError()))
+					.selectors(selectClass(AnonymousSpecClasses.oneSpecThrowingAssertionError()))
 					.execute();
 
 				results.allEvents()

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -87,7 +87,27 @@ public class JavaSpecEngineTest implements SpecClass {
 			assertFalse(onlyChild.isTest());
 		});
 
-		javaspec.pending("#discover discovers a describe block, within a spec class");
+		javaspec.it("#discover discovers a describe block", () -> {
+			JavaSpecEngine subject = new JavaSpecEngine();
+			Class<?> describeSpecClass = specClassWithEmptyDescribeBlock();
+			TestDescriptor returned = subject
+				.discover(classEngineDiscoveryRequest(describeSpecClass), UniqueId.forEngine(subject.getId()));
+
+			assertEquals(1, returned.getChildren().size());
+			TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
+
+			assertEquals(1, specClassDescriptor.getChildren().size());
+			TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
+			UniqueId.Segment idSegment = describeDescriptor.getUniqueId().getLastSegment();
+			assertEquals("describe-block", idSegment.getType());
+			assertEquals("something", idSegment.getValue());
+
+			assertEquals("something", describeDescriptor.getDisplayName());
+			assertEquals(specClassDescriptor, describeDescriptor.getParent().orElseThrow());
+			assertTrue(describeDescriptor.isContainer());
+			assertFalse(describeDescriptor.isRoot());
+			assertFalse(describeDescriptor.isTest());
+		});
 
 		javaspec.it("#discover discovers a pending spec", () -> {
 			JavaSpecEngine subject = new JavaSpecEngine();

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -87,6 +87,8 @@ public class JavaSpecEngineTest implements SpecClass {
 			assertFalse(onlyChild.isTest());
 		});
 
+		javaspec.pending("#discover discovers a describe block, within a spec class");
+
 		javaspec.it("#discover discovers a pending spec", () -> {
 			JavaSpecEngine subject = new JavaSpecEngine();
 			TestDescriptor returned = subject

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -14,7 +14,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.assertj.core.api.Condition;
+import org.assertj.core.util.Lists;
 import org.junit.platform.commons.annotation.Testable;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.TestDescriptor;
@@ -159,6 +161,22 @@ public class JavaSpecEngineTest implements SpecClass {
 			assertFalse(specDescriptor.isRoot());
 			assertTrue(specDescriptor.isTest());
 		});
+
+		javaspec.it("#discover discovers nested describe blocks", () -> {
+			JavaSpecEngine subject = new JavaSpecEngine();
+			TestDescriptor returned = subject.discover(
+				classEngineDiscoveryRequest(AnonymousSpecClasses.describeThenSpec()),
+				UniqueId.forEngine(subject.getId())
+			);
+
+			TestDescriptor specClass = returned.getChildren().iterator().next();
+			List<String> displayNames = specClass.getChildren().stream()
+				.map(TestDescriptor::getDisplayName)
+				.collect(Collectors.toList());
+			assertEquals(Lists.newArrayList("something", "spec"), displayNames);
+		});
+
+		javaspec.pending("#discover discovers two describe blocks, side by side");
 
 		javaspec.it("#execute reports execution events for the engine", () -> {
 			EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -117,6 +117,8 @@ public class JavaSpecEngineTest implements SpecClass {
 			);
 
 			TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
+			assertEquals(1, specClassDescriptor.getChildren().size());
+
 			TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
 			assertEquals(1, describeDescriptor.getChildren().size());
 

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -136,6 +136,8 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertTrue(specDescriptor.isTest());
 			});
 
+			javaspec.pending("discovers specs declared after nested describe blocks, realizing the beauty of a Stack");
+
 			javaspec.it("discovers a pending spec", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
 				TestDescriptor returned = subject.discover(

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -162,7 +162,7 @@ public class JavaSpecEngineTest implements SpecClass {
 			assertTrue(specDescriptor.isTest());
 		});
 
-		javaspec.it("#discover discovers nested describe blocks", () -> {
+		javaspec.it("#discover discovers specs declared after a describe block in the same level of nesting", () -> {
 			JavaSpecEngine subject = new JavaSpecEngine();
 			TestDescriptor returned = subject.discover(
 				classEngineDiscoveryRequest(AnonymousSpecClasses.describeThenSpec()),

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -30,7 +30,7 @@ public class JavaSpecEngineTest implements SpecClass {
 	@Override
 	public void declareSpecs(JavaSpec javaspec) {
 		javaspec.it("can be loaded with ServiceLoader and located by ID", () -> {
-			EngineTestKit.engine("javaspec-engine").selectors(selectClass(nullSpecClass())).execute();
+			EngineTestKit.engine("javaspec-engine").selectors(selectClass(emptySpecClass())).execute();
 		});
 
 		javaspec.describe("#discover", () -> {
@@ -71,7 +71,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("discovers a container for each selected spec class", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
-				Class<?> nullSpecClass = nullSpecClass();
+				Class<?> nullSpecClass = emptySpecClass();
 				TestDescriptor returned = subject
 					.discover(classEngineDiscoveryRequest(nullSpecClass), UniqueId.forEngine(subject.getId()));
 
@@ -92,7 +92,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("discovers a describe block", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
-				Class<?> describeSpecClass = nullDescribeBlock();
+				Class<?> describeSpecClass = emptyDescribe();
 				TestDescriptor returned = subject
 					.discover(classEngineDiscoveryRequest(describeSpecClass), UniqueId.forEngine(subject.getId()));
 
@@ -115,7 +115,7 @@ public class JavaSpecEngineTest implements SpecClass {
 			javaspec.it("discovers a describe block with a spec in it", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
 				TestDescriptor returned = subject.discover(
-					classEngineDiscoveryRequest(describeBlockWithOneSpec()),
+					classEngineDiscoveryRequest(describeWithOneSpec()),
 					UniqueId.forEngine(subject.getId())
 				);
 
@@ -133,7 +133,7 @@ public class JavaSpecEngineTest implements SpecClass {
 			javaspec.it("discovers a pending spec", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
 				TestDescriptor returned = subject
-					.discover(classEngineDiscoveryRequest(pendingSpecClass()), UniqueId.forEngine(subject.getId()));
+					.discover(classEngineDiscoveryRequest(pendingSpec()), UniqueId.forEngine(subject.getId()));
 
 				TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
 				assertEquals(1, specClassDescriptor.getChildren().size());
@@ -147,7 +147,7 @@ public class JavaSpecEngineTest implements SpecClass {
 			javaspec.it("discovers a test for each spec in a spec class", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
 				TestDescriptor returned = subject
-					.discover(classEngineDiscoveryRequest(oneSpecClass()), UniqueId.forEngine(subject.getId()));
+					.discover(classEngineDiscoveryRequest(oneSpec()), UniqueId.forEngine(subject.getId()));
 
 				TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
 				assertEquals(1, specClassDescriptor.getChildren().size());
@@ -189,7 +189,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("skips spec class containers that don't have any specs in them", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-					.selectors(selectClass(nullSpecClass()))
+					.selectors(selectClass(emptySpecClass()))
 					.execute();
 				results.containerEvents()
 					.assertEventsMatchExactly(event(engine(), started()), event(engine(), finishedSuccessfully()));
@@ -197,7 +197,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("reports execution events for spec class containers", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-					.selectors(selectClass(oneSpecClass()))
+					.selectors(selectClass(oneSpec()))
 					.execute();
 
 				results.containerEvents()
@@ -211,7 +211,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("reports start and skipped events for pending specs", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-					.selectors(selectClass(pendingSpecClass()))
+					.selectors(selectClass(pendingSpec()))
 					.execute();
 
 				results.allEvents()
@@ -223,7 +223,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("reports start and successful finish events for passing specs", () -> {
 				EngineExecutionResults results = EngineTestKit.engine(new JavaSpecEngine())
-					.selectors(selectClass(oneSpecClass()))
+					.selectors(selectClass(oneSpec()))
 					.execute();
 
 				results.allEvents()

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -109,23 +109,23 @@ public class JavaSpecEngineTest implements SpecClass {
 			assertFalse(describeDescriptor.isTest());
 		});
 
-		javaspec.it("#discover discovers a describe block with a spec in it", () -> {
-			JavaSpecEngine subject = new JavaSpecEngine();
-			TestDescriptor returned = subject.discover(
-				classEngineDiscoveryRequest(describeBlockWithOneSpec()),
-				UniqueId.forEngine(subject.getId())
-			);
-
-			TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
-			assertEquals(1, specClassDescriptor.getChildren().size());
-
-			TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
-			assertEquals(1, describeDescriptor.getChildren().size());
-
-			TestDescriptor specDescriptor = describeDescriptor.getChildren().iterator().next();
-			assertEquals("works", specDescriptor.getDisplayName());
-			assertTrue(specDescriptor.isTest());
-		});
+//		javaspec.it("#discover discovers a describe block with a spec in it", () -> {
+//			JavaSpecEngine subject = new JavaSpecEngine();
+//			TestDescriptor returned = subject.discover(
+//				classEngineDiscoveryRequest(describeBlockWithOneSpec()),
+//				UniqueId.forEngine(subject.getId())
+//			);
+//
+//			TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
+//			assertEquals(1, specClassDescriptor.getChildren().size());
+//
+//			TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
+//			assertEquals(1, describeDescriptor.getChildren().size());
+//
+//			TestDescriptor specDescriptor = describeDescriptor.getChildren().iterator().next();
+//			assertEquals("works", specDescriptor.getDisplayName());
+//			assertTrue(specDescriptor.isTest());
+//		});
 
 		javaspec.it("#discover discovers a pending spec", () -> {
 			JavaSpecEngine subject = new JavaSpecEngine();


### PR DESCRIPTION
Add preliminary support for `describe` blocks, that occur at a single depth.  Bonus: Add `JavaSpec#pending` too.

I'm intentionally making this a separate PR from full-blown support for `describe` blocks of arbitrary depth because doing so would make it harder to read this PR.


## Future work

* Support nested `describe` blocks
* Support specs declared with `it` and `pending`, after a `describe` block.
* Keep pushing for standard interfaces for spec discovery and execution.