### PR TITLE
Introduce assertJ for engine specs

### DIFF
--- a/prototypes/etc/git-hooks/pre-commit
+++ b/prototypes/etc/git-hooks/pre-commit
@@ -3,7 +3,7 @@
 # Redirect output to stderr.
 exec 1>&2
 
-function checkCodeFormat() {
+checkCodeFormat() {
   echo "[$0] Making sure code is formatted"
   cd prototypes
   exec ./gradlew spotlessCheck

--- a/prototypes/javaspec-engine/build.gradle
+++ b/prototypes/javaspec-engine/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	implementation project(':javaspec-api')
 	implementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 
+	testImplementation 'org.assertj:assertj-core:3.22.0'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
 	testImplementation 'org.junit.platform:junit-platform-testkit:1.8.2'
 //  testRuntimeOnly project(':javaspec-engine-discovery-request-listener')

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -98,10 +98,11 @@ public class JavaSpecEngineTest implements SpecClass {
 					UniqueId.forEngine(subject.getId())
 				);
 
-				assertEquals(1, returned.getChildren().size());
-				TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
+				assertThat(returned).hasChildren(1);
 
-				assertEquals(1, specClassDescriptor.getChildren().size());
+				TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
+				assertThat(specClassDescriptor).hasChildren(1);
+
 				TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
 				assertThat(describeDescriptor)
 					.hasDisplayName("something")
@@ -118,10 +119,10 @@ public class JavaSpecEngineTest implements SpecClass {
 				);
 
 				TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
-				assertEquals(1, specClassDescriptor.getChildren().size());
+				assertThat(specClassDescriptor).hasChildren(1);
 
 				TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
-				assertEquals(1, describeDescriptor.getChildren().size());
+				assertThat(describeDescriptor).hasChildren(1);
 
 				TestDescriptor specDescriptor = describeDescriptor.getChildren().iterator().next();
 				assertThat(specDescriptor)
@@ -139,7 +140,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				);
 
 				TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
-				assertEquals(1, specClassDescriptor.getChildren().size());
+				assertThat(specClassDescriptor).hasChildren(1);
 
 				TestDescriptor specDescriptor = specClassDescriptor.getChildren().iterator().next();
 				assertThat(specDescriptor).hasIdEndingIn("test", "pending spec");
@@ -153,7 +154,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				);
 
 				TestDescriptor specClassDescriptor = returned.getChildren().iterator().next();
-				assertEquals(1, specClassDescriptor.getChildren().size());
+				assertThat(specClassDescriptor).hasChildren(1);
 
 				TestDescriptor specDescriptor = specClassDescriptor.getChildren().iterator().next();
 				assertThat(specDescriptor)
@@ -170,10 +171,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				);
 
 				TestDescriptor specClass = returned.getChildren().iterator().next();
-				List<String> displayNames = specClass.getChildren().stream()
-					.map(TestDescriptor::getDisplayName)
-					.collect(Collectors.toList());
-				assertEquals(Lists.newArrayList("something", "spec"), displayNames);
+				assertThat(specClass).hasChildrenNamed("something", "spec");
 			});
 		});
 

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -93,9 +93,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 				assertEquals(nullSpecClass.getName(), onlyChild.getDisplayName());
 				assertEquals(returned, onlyChild.getParent().orElseThrow());
-				assertTrue(onlyChild.isContainer());
-				assertFalse(onlyChild.isRoot());
-				assertFalse(onlyChild.isTest());
+				assertThat(onlyChild).isRegularContainer();
 			});
 
 			javaspec.it("discovers a describe block", () -> {

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -84,13 +84,8 @@ public class JavaSpecEngineTest implements SpecClass {
 					UniqueId.forEngine(subject.getId())
 				);
 
-				// TODO KDK: Add assertion for children's display names
-				List<TestDescriptor> specClassDescriptors = new ArrayList<>(returned.getChildren());
-				assertEquals(1, returned.getChildren().size());
-
-				TestDescriptor onlyChild = specClassDescriptors.get(0);
-				assertThat(onlyChild)
-					.hasDisplayName(nullSpecClass.getName())
+				assertThat(returned).hasChildrenNamed(nullSpecClass.getName());
+				assertThat(returned.getChildren().iterator().next())
 					.hasIdEndingIn("class", nullSpecClass.getName())
 					.isRegularContainer()
 					.hasParent(returned);

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -88,9 +88,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertEquals(1, returned.getChildren().size());
 
 				TestDescriptor onlyChild = specClassDescriptors.get(0);
-				UniqueId.Segment idSegment = onlyChild.getUniqueId().getLastSegment();
-				assertEquals("class", idSegment.getType());
-				assertEquals(nullSpecClass.getName(), idSegment.getValue());
+				assertThat(onlyChild).hasIdEndingIn("class", nullSpecClass.getName());
 
 				assertThat(onlyChild).hasDisplayName(nullSpecClass.getName());
 				assertThat(onlyChild)
@@ -110,9 +108,10 @@ public class JavaSpecEngineTest implements SpecClass {
 
 				assertEquals(1, specClassDescriptor.getChildren().size());
 				TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
-				UniqueId.Segment idSegment = describeDescriptor.getUniqueId().getLastSegment();
-				assertEquals("describe-block", idSegment.getType());
-				assertEquals("something", idSegment.getValue());
+				assertThat(describeDescriptor).hasIdEndingIn(
+					"describe-block",
+					"something"
+				);
 
 				assertThat(describeDescriptor).hasDisplayName("something");
 				assertThat(describeDescriptor).hasParent(specClassDescriptor);
@@ -152,9 +151,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertEquals(1, specClassDescriptor.getChildren().size());
 
 				TestDescriptor specDescriptor = specClassDescriptor.getChildren().iterator().next();
-				UniqueId.Segment idSegment = specDescriptor.getUniqueId().getLastSegment();
-				assertEquals("test", idSegment.getType());
-				assertEquals("pending spec", idSegment.getValue());
+				assertThat(specDescriptor).hasIdEndingIn("test", "pending spec");
 			});
 
 			javaspec.it("discovers a test for each spec in a spec class", () -> {
@@ -168,9 +165,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertEquals(1, specClassDescriptor.getChildren().size());
 
 				TestDescriptor specDescriptor = specClassDescriptor.getChildren().iterator().next();
-				UniqueId.Segment idSegment = specDescriptor.getUniqueId().getLastSegment();
-				assertEquals("test", idSegment.getType());
-				assertEquals("one spec", idSegment.getValue());
+				assertThat(specDescriptor).hasIdEndingIn("test", "one spec");
 
 				assertThat(specDescriptor).hasParent(specClassDescriptor);
 				assertFalse(specDescriptor.isContainer());

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -3,6 +3,7 @@ package info.javaspec.engine;
 import static info.javaspec.engine.DiscoverySelectorFactory.nullDiscoverySelector;
 import static info.javaspec.engine.EngineDiscoveryRequestFactory.classEngineDiscoveryRequest;
 import static info.javaspec.engine.EngineDiscoveryRequestFactory.nullEngineDiscoveryRequest;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.testkit.engine.EventConditions.*;
@@ -48,11 +49,12 @@ public class JavaSpecEngineTest implements SpecClass {
 				UniqueId engineId = UniqueId.forEngine(subject.getId());
 
 				TestDescriptor returned = subject.discover(nullEngineDiscoveryRequest(), engineId);
-				assertEquals(engineId, returned.getUniqueId());
-				assertEquals("JavaSpec", returned.getDisplayName());
-				assertEquals(Optional.empty(), returned.getParent());
-				assertTrue(returned.isContainer());
-				assertTrue(returned.isRoot());
+				assertThat(returned.getUniqueId()).isEqualTo(engineId);
+				assertThat(returned.getDisplayName()).isEqualTo("JavaSpec");
+				assertThat(returned.getParent()).isEmpty();
+				assertThat(returned.isContainer()).isTrue();
+				assertThat(returned.isRoot()).isTrue();
+				assertThat(returned.isTest()).isFalse();
 			});
 
 			javaspec.it("discovers no containers or tests, given no selectors", () -> {

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -50,7 +50,7 @@ public class JavaSpecEngineTest implements SpecClass {
 
 				TestDescriptor returned = subject.discover(nullEngineDiscoveryRequest(), engineId);
 				assertThat(returned.getUniqueId()).isEqualTo(engineId);
-				assertThat(returned.getDisplayName()).isEqualTo("JavaSpec");
+				assertThat(returned).hasDisplayName("JavaSpec");
 				assertThat(returned.getParent()).isEmpty();
 				assertThat(returned).isRootContainer();
 			});
@@ -92,7 +92,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertEquals("class", idSegment.getType());
 				assertEquals(nullSpecClass.getName(), idSegment.getValue());
 
-				assertEquals(nullSpecClass.getName(), onlyChild.getDisplayName()); // TODO KDK: Add assertion for name and ID
+				assertThat(onlyChild).hasDisplayName(nullSpecClass.getName());
 				assertThat(onlyChild)
 					.isRegularContainer()
 					.hasParent(returned);
@@ -114,7 +114,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertEquals("describe-block", idSegment.getType());
 				assertEquals("something", idSegment.getValue());
 
-				assertEquals("something", describeDescriptor.getDisplayName());
+				assertThat(describeDescriptor).hasDisplayName("something");
 				assertEquals(specClassDescriptor, describeDescriptor.getParent().orElseThrow());
 				assertTrue(describeDescriptor.isContainer());
 				assertFalse(describeDescriptor.isRoot());
@@ -135,7 +135,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertEquals(1, describeDescriptor.getChildren().size());
 
 				TestDescriptor specDescriptor = describeDescriptor.getChildren().iterator().next();
-				assertEquals("works", specDescriptor.getDisplayName());
+				assertThat(specDescriptor).hasDisplayName("works");
 				assertTrue(specDescriptor.isTest());
 			});
 

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -11,12 +11,8 @@ import static org.junit.platform.testkit.engine.EventConditions.*;
 
 import info.javaspec.api.JavaSpec;
 import info.javaspec.api.SpecClass;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.assertj.core.api.Condition;
-import org.assertj.core.util.Lists;
 import org.junit.platform.commons.annotation.Testable;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.TestDescriptor;

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -88,10 +88,9 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertEquals(1, returned.getChildren().size());
 
 				TestDescriptor onlyChild = specClassDescriptors.get(0);
-				assertThat(onlyChild).hasIdEndingIn("class", nullSpecClass.getName());
-
-				assertThat(onlyChild).hasDisplayName(nullSpecClass.getName());
 				assertThat(onlyChild)
+					.hasDisplayName(nullSpecClass.getName())
+					.hasIdEndingIn("class", nullSpecClass.getName())
 					.isRegularContainer()
 					.hasParent(returned);
 			});

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -83,6 +83,7 @@ public class JavaSpecEngineTest implements SpecClass {
 					UniqueId.forEngine(subject.getId())
 				);
 
+				// TODO KDK: Add assertion for children's display names
 				List<TestDescriptor> specClassDescriptors = new ArrayList<>(returned.getChildren());
 				assertEquals(1, returned.getChildren().size());
 
@@ -91,9 +92,10 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertEquals("class", idSegment.getType());
 				assertEquals(nullSpecClass.getName(), idSegment.getValue());
 
-				assertEquals(nullSpecClass.getName(), onlyChild.getDisplayName());
-				assertThat(onlyChild).hasParent(returned);
-				assertThat(onlyChild).isRegularContainer();
+				assertEquals(nullSpecClass.getName(), onlyChild.getDisplayName()); // TODO KDK: Add assertion for name and ID
+				assertThat(onlyChild)
+					.isRegularContainer()
+					.hasParent(returned);
 			});
 
 			javaspec.it("discovers a describe block", () -> {

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -115,7 +115,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertEquals("something", idSegment.getValue());
 
 				assertThat(describeDescriptor).hasDisplayName("something");
-				assertEquals(specClassDescriptor, describeDescriptor.getParent().orElseThrow());
+				assertThat(describeDescriptor).hasParent(specClassDescriptor);
 				assertTrue(describeDescriptor.isContainer());
 				assertFalse(describeDescriptor.isRoot());
 				assertFalse(describeDescriptor.isTest());
@@ -172,7 +172,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertEquals("test", idSegment.getType());
 				assertEquals("one spec", idSegment.getValue());
 
-				assertEquals(specClassDescriptor, specDescriptor.getParent().orElseThrow());
+				assertThat(specDescriptor).hasParent(specClassDescriptor);
 				assertFalse(specDescriptor.isContainer());
 				assertFalse(specDescriptor.isRoot());
 				assertTrue(specDescriptor.isTest());

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -92,7 +92,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertEquals(nullSpecClass.getName(), idSegment.getValue());
 
 				assertEquals(nullSpecClass.getName(), onlyChild.getDisplayName());
-				assertEquals(returned, onlyChild.getParent().orElseThrow());
+				assertThat(onlyChild).hasParent(returned);
 				assertThat(onlyChild).isRegularContainer();
 			});
 

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -12,7 +12,6 @@ import static org.junit.platform.testkit.engine.EventConditions.*;
 import info.javaspec.api.JavaSpec;
 import info.javaspec.api.SpecClass;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -58,10 +57,12 @@ public class JavaSpecEngineTest implements SpecClass {
 
 			javaspec.it("discovers no containers or tests, given no selectors", () -> {
 				JavaSpecEngine subject = new JavaSpecEngine();
+				TestDescriptor returned = subject.discover(
+					nullEngineDiscoveryRequest(),
+					UniqueId.forEngine(subject.getId())
+				);
 
-				TestDescriptor returned = subject.discover(nullEngineDiscoveryRequest(), UniqueId.forEngine(subject.getId()));
-				assertEquals(Collections.emptySet(), returned.getChildren());
-				assertFalse(returned.isTest());
+				assertThat(returned).hasNoChildren();
 			});
 
 			javaspec.it("ignores selectors for classes that are not SpecClass", () -> {
@@ -70,7 +71,8 @@ public class JavaSpecEngineTest implements SpecClass {
 					classEngineDiscoveryRequest(AnonymousSpecClasses.notASpecClass()),
 					UniqueId.forEngine(subject.getId())
 				);
-				assertEquals(Collections.emptySet(), returned.getChildren());
+
+				assertThat(returned).hasNoChildren();
 			});
 
 			javaspec.it("discovers a container for each selected spec class", () -> {

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -107,16 +107,11 @@ public class JavaSpecEngineTest implements SpecClass {
 
 				assertEquals(1, specClassDescriptor.getChildren().size());
 				TestDescriptor describeDescriptor = specClassDescriptor.getChildren().iterator().next();
-				assertThat(describeDescriptor).hasIdEndingIn(
-					"describe-block",
-					"something"
-				);
-
-				assertThat(describeDescriptor).hasDisplayName("something");
-				assertThat(describeDescriptor).hasParent(specClassDescriptor);
-				assertTrue(describeDescriptor.isContainer());
-				assertFalse(describeDescriptor.isRoot());
-				assertFalse(describeDescriptor.isTest());
+				assertThat(describeDescriptor)
+					.hasDisplayName("something")
+					.hasIdEndingIn("describe-block", "something")
+					.hasParent(specClassDescriptor)
+					.isRegularContainer();
 			});
 
 			javaspec.it("discovers a describe block with a spec in it", () -> {
@@ -133,8 +128,9 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertEquals(1, describeDescriptor.getChildren().size());
 
 				TestDescriptor specDescriptor = describeDescriptor.getChildren().iterator().next();
-				assertThat(specDescriptor).hasDisplayName("works");
-				assertTrue(specDescriptor.isTest());
+				assertThat(specDescriptor)
+					.hasDisplayName("works")
+					.isJustATest();
 			});
 
 			javaspec.pending("discovers specs declared after nested describe blocks, realizing the beauty of a Stack");
@@ -164,12 +160,10 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertEquals(1, specClassDescriptor.getChildren().size());
 
 				TestDescriptor specDescriptor = specClassDescriptor.getChildren().iterator().next();
-				assertThat(specDescriptor).hasIdEndingIn("test", "one spec");
-
-				assertThat(specDescriptor).hasParent(specClassDescriptor);
-				assertFalse(specDescriptor.isContainer());
-				assertFalse(specDescriptor.isRoot());
-				assertTrue(specDescriptor.isTest());
+				assertThat(specDescriptor)
+					.hasIdEndingIn("test", "one spec")
+					.hasParent(specClassDescriptor)
+					.isJustATest();
 			});
 
 			javaspec.it("discovers specs declared after a describe block in the same level of nesting", () -> {

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -3,6 +3,7 @@ package info.javaspec.engine;
 import static info.javaspec.engine.DiscoverySelectorFactory.nullDiscoverySelector;
 import static info.javaspec.engine.EngineDiscoveryRequestFactory.classEngineDiscoveryRequest;
 import static info.javaspec.engine.EngineDiscoveryRequestFactory.nullEngineDiscoveryRequest;
+import static info.javaspec.engine.TestDescriptorAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
@@ -52,9 +53,7 @@ public class JavaSpecEngineTest implements SpecClass {
 				assertThat(returned.getUniqueId()).isEqualTo(engineId);
 				assertThat(returned.getDisplayName()).isEqualTo("JavaSpec");
 				assertThat(returned.getParent()).isEmpty();
-				assertThat(returned.isContainer()).isTrue();
-				assertThat(returned.isRoot()).isTrue();
-				assertThat(returned.isTest()).isFalse();
+				assertThat(returned).isRootContainer();
 			});
 
 			javaspec.it("discovers no containers or tests, given no selectors", () -> {

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -49,10 +49,11 @@ public class JavaSpecEngineTest implements SpecClass {
 				UniqueId engineId = UniqueId.forEngine(subject.getId());
 
 				TestDescriptor returned = subject.discover(nullEngineDiscoveryRequest(), engineId);
-				assertThat(returned.getUniqueId()).isEqualTo(engineId);
-				assertThat(returned).hasDisplayName("JavaSpec");
+				assertThat(returned)
+					.hasDisplayName("JavaSpec")
+					.hasUniqueId(engineId)
+					.isRootContainer();
 				assertThat(returned.getParent()).isEmpty();
-				assertThat(returned).isRootContainer();
 			});
 
 			javaspec.it("discovers no containers or tests, given no selectors", () -> {

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -2,6 +2,7 @@ package info.javaspec.engine;
 
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Optional;
 import org.assertj.core.api.AbstractAssert;
 import org.junit.platform.engine.TestDescriptor;
 
@@ -23,6 +24,26 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 				Collections.emptySet(),
 				"Expected TestDescriptor to have no children"
 			);
+		}
+
+		return this;
+	}
+
+	public TestDescriptorAssert hasParent(TestDescriptor expected) {
+		isNotNull();
+
+		Optional<TestDescriptor> parent = actual.getParent();
+		if (parent.isEmpty()) {
+			failWithMessage(
+				String.format(
+					"Expected TestDescriptor to have parent named <%s>, but was null",
+					expected.getDisplayName()
+				)
+			);
+		}
+
+		if (parent.orElseThrow() != expected) {
+			failureWithActualExpected(parent.orElseThrow(), expected, "Expected TestDescriptor to have parent");
 		}
 
 		return this;

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.assertj.core.api.AbstractAssert;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.UniqueId.Segment;
 
 //Assertions on Jupiter TestDescriptors
@@ -77,6 +78,19 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 				"Expected TestDescriptor to have parent <%s> but was <%s>",
 				expectedParent,
 				actualParent.orElseThrow()
+			);
+		}
+
+		return this;
+	}
+
+	public TestDescriptorAssert hasUniqueId(UniqueId expected) {
+		isNotNull();
+		if (!Objects.equals(actual.getUniqueId(), expected)) {
+			failWithMessage(
+				"Expected TestDescriptor to have UniqueId <%s> but was <%s>",
+				expected,
+				actual.getUniqueId()
 			);
 		}
 

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -106,4 +106,16 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 
 		return this;
 	}
+
+	public TestDescriptorAssert isJustATest() {
+		isNotNull();
+		if (actual.isContainer())
+			failWithMessage("Expected TestDescriptor to not be a container that can contain other descriptors");
+		if (actual.isRoot())
+			failWithMessage("Expected TestDescriptor to not be a root container that contains everything else");
+		if (!actual.isTest())
+			failWithMessage("Expected TestDescriptor to be a test");
+
+		return this;
+	}
 }

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -28,6 +28,18 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 		return this;
 	}
 
+	public TestDescriptorAssert isRegularContainer() {
+		isNotNull();
+		if (!actual.isContainer())
+			failWithMessage("Expected TestDescriptor to be a container that can contain other descriptors");
+		if (actual.isRoot())
+			failWithMessage("Expected TestDescriptor not to be a root container");
+		if (actual.isTest())
+			failWithMessage("Expected TestDescriptor not to be a test");
+
+		return this;
+	}
+
 	public TestDescriptorAssert isRootContainer() {
 		isNotNull();
 		if (!actual.isContainer())

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -1,0 +1,27 @@
+package info.javaspec.engine;
+
+import org.assertj.core.api.AbstractAssert;
+import org.junit.platform.engine.TestDescriptor;
+
+//Assertions on Jupiter TestDescriptors
+public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, TestDescriptor> {
+	public static TestDescriptorAssert assertThat(TestDescriptor actual) {
+		return new TestDescriptorAssert(actual);
+	}
+
+	public TestDescriptorAssert(TestDescriptor testDescriptor) {
+		super(testDescriptor, TestDescriptorAssert.class);
+	}
+
+	public TestDescriptorAssert isRootContainer() {
+		isNotNull();
+		if (!actual.isContainer())
+			failWithMessage("Expected TestDescriptor to be a container that can contain other descriptors");
+		if (!actual.isRoot())
+			failWithMessage("Expected TestDescriptor to be a root container that contains everything else");
+		if (actual.isTest())
+			failWithMessage("Expected TestDescriptor not to be a test");
+
+		return this;
+	}
+}

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.AbstractAssert;
@@ -22,6 +23,22 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 		super(testDescriptor, TestDescriptorAssert.class);
 	}
 
+  public TestDescriptorAssert hasChildren(int expectedNum) {
+		isNotNull();
+
+		Set<? extends TestDescriptor> actualChildren = actual.getChildren();
+		if (actualChildren.size() != expectedNum) {
+			failWithMessage(
+				"Expected TestDescriptor to have <%d> children but has <%d>: <%s>",
+				expectedNum,
+				actualChildren.size(),
+				actualChildren
+			);
+		}
+
+		return this;
+  }
+
 	public TestDescriptorAssert hasChildrenNamed(String name) {
 		isNotNull();
 		List<String> displayNames = actual.getChildren()
@@ -30,6 +47,17 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 			.collect(Collectors.toList());
 
 		Assertions.assertThat(displayNames).containsExactly(name);
+		return this;
+	}
+
+	public TestDescriptorAssert hasChildrenNamed(String first, String last) {
+		isNotNull();
+		List<String> displayNames = actual.getChildren()
+			.stream()
+			.map(x -> x.getDisplayName())
+			.collect(Collectors.toList());
+
+		Assertions.assertThat(displayNames).containsExactly(first, last);
 		return this;
 	}
 

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -1,9 +1,13 @@
 package info.javaspec.engine;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.UniqueId.Segment;
@@ -16,6 +20,17 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 
 	public TestDescriptorAssert(TestDescriptor testDescriptor) {
 		super(testDescriptor, TestDescriptorAssert.class);
+	}
+
+	public TestDescriptorAssert hasChildrenNamed(String name) {
+		isNotNull();
+		List<String> displayNames = actual.getChildren()
+			.stream()
+			.map(x -> x.getDisplayName())
+			.collect(Collectors.toList());
+
+		Assertions.assertThat(displayNames).containsExactly(name);
+		return this;
 	}
 
 	public TestDescriptorAssert hasDisplayName(String expected) {

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -18,7 +18,7 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 		return new TestDescriptorAssert(actual);
 	}
 
-	public TestDescriptorAssert(TestDescriptor testDescriptor) {
+	private TestDescriptorAssert(TestDescriptor testDescriptor) {
 		super(testDescriptor, TestDescriptorAssert.class);
 	}
 
@@ -128,6 +128,18 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 		return this;
 	}
 
+	public TestDescriptorAssert isJustATest() {
+		isNotNull();
+		if (actual.isContainer())
+			failWithMessage("Expected TestDescriptor to not be a container that can contain other descriptors");
+		if (actual.isRoot())
+			failWithMessage("Expected TestDescriptor to not be a root container that contains everything else");
+		if (!actual.isTest())
+			failWithMessage("Expected TestDescriptor to be a test");
+
+		return this;
+	}
+
 	public TestDescriptorAssert isRegularContainer() {
 		isNotNull();
 		if (!actual.isContainer())
@@ -148,18 +160,6 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 			failWithMessage("Expected TestDescriptor to be a root container that contains everything else");
 		if (actual.isTest())
 			failWithMessage("Expected TestDescriptor not to be a test");
-
-		return this;
-	}
-
-	public TestDescriptorAssert isJustATest() {
-		isNotNull();
-		if (actual.isContainer())
-			failWithMessage("Expected TestDescriptor to not be a container that can contain other descriptors");
-		if (actual.isRoot())
-			failWithMessage("Expected TestDescriptor to not be a root container that contains everything else");
-		if (!actual.isTest())
-			failWithMessage("Expected TestDescriptor to be a test");
 
 		return this;
 	}

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -1,5 +1,7 @@
 package info.javaspec.engine;
 
+import java.util.Collections;
+import java.util.Objects;
 import org.assertj.core.api.AbstractAssert;
 import org.junit.platform.engine.TestDescriptor;
 
@@ -11,6 +13,19 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 
 	public TestDescriptorAssert(TestDescriptor testDescriptor) {
 		super(testDescriptor, TestDescriptorAssert.class);
+	}
+
+	public TestDescriptorAssert hasNoChildren() {
+		isNotNull();
+		if (!Objects.equals(actual.getChildren(), Collections.emptySet())) {
+			failureWithActualExpected(
+				actual.getChildren(),
+				Collections.emptySet(),
+				"Expected TestDescriptor to have no children"
+			);
+		}
+
+		return this;
 	}
 
 	public TestDescriptorAssert isRootContainer() {

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -16,6 +16,19 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 		super(testDescriptor, TestDescriptorAssert.class);
 	}
 
+	public TestDescriptorAssert hasDisplayName(String expected) {
+		isNotNull();
+		if (!Objects.equals(actual.getDisplayName(), expected)) {
+			failWithMessage(
+				"Expected TestDescriptor to have display name <%s> but was <%s>",
+				expected,
+				actual.getDisplayName()
+			);
+		}
+
+		return this;
+	}
+
 	public TestDescriptorAssert hasNoChildren() {
 		isNotNull();
 		if (!Objects.equals(actual.getChildren(), Collections.emptySet())) {

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -19,31 +19,34 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 	public TestDescriptorAssert hasNoChildren() {
 		isNotNull();
 		if (!Objects.equals(actual.getChildren(), Collections.emptySet())) {
-			failureWithActualExpected(
-				actual.getChildren(),
-				Collections.emptySet(),
-				"Expected TestDescriptor to have no children"
+			failWithMessage(
+				"Expected TestDescriptor to have no children but was <%s>",
+				actual.getChildren()
 			);
 		}
 
 		return this;
 	}
 
-	public TestDescriptorAssert hasParent(TestDescriptor expected) {
+	public TestDescriptorAssert hasParent(TestDescriptor expectedParent) {
 		isNotNull();
 
-		Optional<TestDescriptor> parent = actual.getParent();
-		if (parent.isEmpty()) {
+		Optional<TestDescriptor> actualParent = actual.getParent();
+		if (actualParent.isEmpty()) {
 			failWithMessage(
 				String.format(
 					"Expected TestDescriptor to have parent named <%s>, but was null",
-					expected.getDisplayName()
+					expectedParent
 				)
 			);
 		}
 
-		if (parent.orElseThrow() != expected) {
-			failureWithActualExpected(parent.orElseThrow(), expected, "Expected TestDescriptor to have parent");
+		if (!Objects.equals(actualParent.orElseThrow(), expectedParent)) {
+			failWithMessage(
+				"Expected TestDescriptor to have parent <%s> but was <%s>",
+				expectedParent,
+				actualParent.orElseThrow()
+			);
 		}
 
 		return this;

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.assertj.core.api.AbstractAssert;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId.Segment;
 
 //Assertions on Jupiter TestDescriptors
 public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, TestDescriptor> {
@@ -23,6 +24,23 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 				"Expected TestDescriptor to have display name <%s> but was <%s>",
 				expected,
 				actual.getDisplayName()
+			);
+		}
+
+		return this;
+	}
+
+	public TestDescriptorAssert hasIdEndingIn(String type, String value) {
+		isNotNull();
+		Segment actualSegment = actual.getUniqueId().getLastSegment();
+
+		if (!Objects.equals(actualSegment.getType(), type)
+			|| !Objects.equals(actualSegment.getValue(), value)) {
+			failWithMessage(
+				"Expected TestDescriptor's UniqueId to end in <%s:%s> but was <%s>",
+				type,
+				value,
+				actualSegment
 			);
 		}
 

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -38,25 +38,14 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 		return this;
 	}
 
-	public TestDescriptorAssert hasChildrenNamed(String name) {
+	public TestDescriptorAssert hasChildrenNamed(String... displayNames) {
 		isNotNull();
-		List<String> displayNames = actual.getChildren()
+		List<String> actualNames = actual.getChildren()
 			.stream()
 			.map(x -> x.getDisplayName())
 			.collect(Collectors.toList());
 
-		Assertions.assertThat(displayNames).containsExactly(name);
-		return this;
-	}
-
-	public TestDescriptorAssert hasChildrenNamed(String first, String last) {
-		isNotNull();
-		List<String> displayNames = actual.getChildren()
-			.stream()
-			.map(x -> x.getDisplayName())
-			.collect(Collectors.toList());
-
-		Assertions.assertThat(displayNames).containsExactly(first, last);
+		Assertions.assertThat(actualNames).containsExactly(displayNames);
 		return this;
 	}
 

--- a/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/prototypes/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.platform.engine.TestDescriptor;
@@ -23,7 +22,7 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 		super(testDescriptor, TestDescriptorAssert.class);
 	}
 
-  public TestDescriptorAssert hasChildren(int expectedNum) {
+	public TestDescriptorAssert hasChildren(int expectedNum) {
 		isNotNull();
 
 		Set<? extends TestDescriptor> actualChildren = actual.getChildren();
@@ -37,7 +36,7 @@ public class TestDescriptorAssert extends AbstractAssert<TestDescriptorAssert, T
 		}
 
 		return this;
-  }
+	}
 
 	public TestDescriptorAssert hasChildrenNamed(String name) {
 		isNotNull();


### PR DESCRIPTION
Use AssertJ for the specs on the new `JavaSpecEngine`, to make them a bit easier to read.

Also fixed the Git pre-commit hook, to be compatible with WSL's chosen `dash`.