### PR TITLE
Refactor TestDescriptors to be Composites

### DIFF
--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/ContextDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/ContextDescriptor.java
@@ -1,11 +1,14 @@
 package info.javaspec.engine;
 
 import info.javaspec.api.SpecClass;
+import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 
 //Adapter for various context blocks that makes it work like a Jupiter test container.
-final class ContextDescriptor extends AbstractTestDescriptor {
+final class ContextDescriptor extends AbstractTestDescriptor implements ExecutableTestDescriptor {
 	public static ContextDescriptor declaringClass(UniqueId parentId, Class<? extends SpecClass> declaringClass) {
 		return new ContextDescriptor(
 			parentId.append("class", declaringClass.getName()),
@@ -34,5 +37,19 @@ final class ContextDescriptor extends AbstractTestDescriptor {
 	@Override
 	public Type getType() {
 		return Type.CONTAINER;
+	}
+
+	/* JavaSpec */
+
+	@Override
+	public void execute(EngineExecutionListener listener) {
+		listener.executionStarted(this);
+
+		for (TestDescriptor child : this.getChildren()) {
+			ExecutableTestDescriptor executableChild = ExecutableTestDescriptor.class.cast(child);
+			executableChild.execute(listener);
+		}
+
+		listener.executionFinished(this, TestExecutionResult.successful());
 	}
 }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/ContextDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/ContextDescriptor.java
@@ -23,6 +23,10 @@ final class ContextDescriptor extends AbstractTestDescriptor implements Executab
 		);
 	}
 
+	public static ContextDescriptor engine(UniqueId engineId) {
+		return new ContextDescriptor(engineId, "JavaSpec");
+	}
+
 	public static ContextDescriptor given(UniqueId parentId, String what) {
 		return new ContextDescriptor(
 			parentId.append("given-block", what),

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/ContextDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/ContextDescriptor.java
@@ -9,7 +9,11 @@ import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 
 //Adapter for various context blocks that makes it work like a Jupiter test container.
 final class ContextDescriptor extends AbstractTestDescriptor implements ExecutableTestDescriptor {
-	public static ContextDescriptor declaringClass(UniqueId parentId, Class<? extends SpecClass> declaringClass) {
+	public static ContextDescriptor forEngine(UniqueId engineId) {
+		return new ContextDescriptor(engineId, "JavaSpec");
+	}
+
+	public static ContextDescriptor forDeclaringClass(UniqueId parentId, Class<? extends SpecClass> declaringClass) {
 		return new ContextDescriptor(
 			parentId.append("class", declaringClass.getName()),
 			declaringClass.getName()
@@ -21,10 +25,6 @@ final class ContextDescriptor extends AbstractTestDescriptor implements Executab
 			parentId.append("describe-block", what),
 			what
 		);
-	}
-
-	public static ContextDescriptor engine(UniqueId engineId) {
-		return new ContextDescriptor(engineId, "JavaSpec");
 	}
 
 	public static ContextDescriptor given(UniqueId parentId, String what) {

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/ExecutableTestDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/ExecutableTestDescriptor.java
@@ -3,7 +3,7 @@ package info.javaspec.engine;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestDescriptor;
 
-//Adapter for JavaSpec containers or tests that runs on Jupiter.
+//Composite adapter for JavaSpec containers or tests that runs on Jupiter and only contains other executable descriptors.
 interface ExecutableTestDescriptor extends TestDescriptor {
 	void execute(EngineExecutionListener listener);
 }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/ExecutableTestDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/ExecutableTestDescriptor.java
@@ -1,0 +1,8 @@
+package info.javaspec.engine;
+
+import org.junit.platform.engine.EngineExecutionListener;
+
+//Adapter for JavaSpec containers or tests that runs on Jupiter.
+interface ExecutableTestDescriptor {
+	void execute(EngineExecutionListener listener);
+}

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/ExecutableTestDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/ExecutableTestDescriptor.java
@@ -1,8 +1,9 @@
 package info.javaspec.engine;
 
 import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.TestDescriptor;
 
 //Adapter for JavaSpec containers or tests that runs on Jupiter.
-interface ExecutableTestDescriptor {
+interface ExecutableTestDescriptor extends TestDescriptor {
 	void execute(EngineExecutionListener listener);
 }

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecDescriptor.java
@@ -1,8 +1,0 @@
-package info.javaspec.engine;
-
-import org.junit.platform.engine.EngineExecutionListener;
-
-//Adapter for a JavaSpec container or test of some sort that works likes its Jupiter counterpart.
-interface JavaSpecDescriptor {
-	void execute(EngineExecutionListener listener);
-}

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import org.junit.platform.engine.*;
 import org.junit.platform.engine.discovery.ClassSelector;
-import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 
 // Orchestrates the process of discovering and running specs in a Jupiter runtime.
 public class JavaSpecEngine implements TestEngine {
@@ -25,7 +24,7 @@ public class JavaSpecEngine implements TestEngine {
 		this.loader.findFirst()
 			.ifPresent(listener -> listener.onDiscover(discoveryRequest));
 
-		EngineDescriptor engineDescriptor = new EngineDescriptor(engineId, "JavaSpec");
+		TestDescriptor engineDescriptor = ContextDescriptor.engine(engineId);
 		discoveryRequest.getSelectorsByType(ClassSelector.class)
 			.stream()
 			.map(ClassSelector::getJavaClass)
@@ -46,17 +45,6 @@ public class JavaSpecEngine implements TestEngine {
 	}
 
 	private void execute(TestDescriptor descriptor, EngineExecutionListener listener) {
-		if (descriptor.isRoot()) {
-			listener.executionStarted(descriptor);
-
-			for (TestDescriptor child : descriptor.getChildren()) {
-				execute(child, listener);
-			}
-
-			listener.executionFinished(descriptor, TestExecutionResult.successful());
-			return;
-		}
-
 		if (descriptor instanceof ExecutableTestDescriptor) {
 			ExecutableTestDescriptor spec = ExecutableTestDescriptor.class.cast(descriptor);
 			spec.execute(listener);

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -24,7 +24,7 @@ public class JavaSpecEngine implements TestEngine {
 		this.loader.findFirst()
 			.ifPresent(listener -> listener.onDiscover(discoveryRequest));
 
-		ExecutableTestDescriptor engineDescriptor = ContextDescriptor.engine(engineId);
+		ExecutableTestDescriptor engineDescriptor = ContextDescriptor.forEngine(engineId);
 		discoveryRequest.getSelectorsByType(ClassSelector.class)
 			.stream()
 			.map(ClassSelector::getJavaClass)

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -46,14 +46,7 @@ public class JavaSpecEngine implements TestEngine {
 	}
 
 	private void execute(TestDescriptor descriptor, EngineExecutionListener listener) {
-		if (descriptor instanceof ExecutableTestDescriptor) {
-			ExecutableTestDescriptor spec = ExecutableTestDescriptor.class.cast(descriptor);
-			spec.execute(listener);
-			return;
-		}
-
-		switch (descriptor.getType()) {
-		case CONTAINER:
+		if (descriptor.isRoot()) {
 			listener.executionStarted(descriptor);
 
 			for (TestDescriptor child : descriptor.getChildren()) {
@@ -62,10 +55,15 @@ public class JavaSpecEngine implements TestEngine {
 
 			listener.executionFinished(descriptor, TestExecutionResult.successful());
 			return;
-
-		default:
-			throw new UnsupportedOperationException(String.format("Unsupported TestDescriptor: %s", descriptor));
 		}
+
+		if (descriptor instanceof ExecutableTestDescriptor) {
+			ExecutableTestDescriptor spec = ExecutableTestDescriptor.class.cast(descriptor);
+			spec.execute(listener);
+			return;
+		}
+
+		throw new UnsupportedOperationException(String.format("Unsupported TestDescriptor: %s", descriptor));
 	}
 
 	@Override

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -24,7 +24,7 @@ public class JavaSpecEngine implements TestEngine {
 		this.loader.findFirst()
 			.ifPresent(listener -> listener.onDiscover(discoveryRequest));
 
-		TestDescriptor engineDescriptor = ContextDescriptor.engine(engineId);
+		ExecutableTestDescriptor engineDescriptor = ContextDescriptor.engine(engineId);
 		discoveryRequest.getSelectorsByType(ClassSelector.class)
 			.stream()
 			.map(ClassSelector::getJavaClass)
@@ -39,19 +39,8 @@ public class JavaSpecEngine implements TestEngine {
 
 	@Override
 	public void execute(ExecutionRequest request) {
-		TestDescriptor rootDescriptor = request.getRootTestDescriptor();
-		EngineExecutionListener listener = request.getEngineExecutionListener();
-		execute(rootDescriptor, listener);
-	}
-
-	private void execute(TestDescriptor descriptor, EngineExecutionListener listener) {
-		if (descriptor instanceof ExecutableTestDescriptor) {
-			ExecutableTestDescriptor spec = ExecutableTestDescriptor.class.cast(descriptor);
-			spec.execute(listener);
-			return;
-		}
-
-		throw new UnsupportedOperationException(String.format("Unsupported TestDescriptor: %s", descriptor));
+		ExecutableTestDescriptor engineDescriptor = ExecutableTestDescriptor.class.cast(request.getRootTestDescriptor());
+		engineDescriptor.execute(request.getEngineExecutionListener());
 	}
 
 	@Override

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -46,6 +46,12 @@ public class JavaSpecEngine implements TestEngine {
 	}
 
 	private void execute(TestDescriptor descriptor, EngineExecutionListener listener) {
+		if (descriptor instanceof ExecutableTestDescriptor) {
+			ExecutableTestDescriptor spec = ExecutableTestDescriptor.class.cast(descriptor);
+			spec.execute(listener);
+			return;
+		}
+
 		switch (descriptor.getType()) {
 		case CONTAINER:
 			listener.executionStarted(descriptor);
@@ -55,11 +61,6 @@ public class JavaSpecEngine implements TestEngine {
 			}
 
 			listener.executionFinished(descriptor, TestExecutionResult.successful());
-			return;
-
-		case TEST:
-			JavaSpecDescriptor spec = JavaSpecDescriptor.class.cast(descriptor);
-			spec.execute(listener);
 			return;
 
 		default:

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/PendingSpecDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/PendingSpecDescriptor.java
@@ -5,7 +5,7 @@ import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 
 //Adapter for a pending spec that makes it work like a skipped Jupiter test.
-final class PendingSpecDescriptor extends AbstractTestDescriptor implements JavaSpecDescriptor {
+final class PendingSpecDescriptor extends AbstractTestDescriptor implements ExecutableTestDescriptor {
 	public static PendingSpecDescriptor of(UniqueId parentId, String behavior) {
 		return new PendingSpecDescriptor(parentId.append("test", behavior), behavior);
 	}

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDeclaration.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDeclaration.java
@@ -29,7 +29,7 @@ final class SpecClassDeclaration implements JavaSpec {
 	}
 
 	private ContextDescriptor discover(UniqueId engineId, SpecClass declaringInstance) {
-		enterScope(ContextDescriptor.declaringClass(engineId, declaringInstance.getClass()));
+		enterScope(ContextDescriptor.forDeclaringClass(engineId, declaringInstance.getClass()));
 		declaringInstance.declareSpecs(this);
 		return exitScope();
 	}

--- a/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecDescriptor.java
+++ b/prototypes/javaspec-engine/src/main/java/info/javaspec/engine/SpecDescriptor.java
@@ -7,7 +7,7 @@ import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 
 //Adapter for a spec that makes it work like a Jupiter test.
-final class SpecDescriptor extends AbstractTestDescriptor implements JavaSpecDescriptor {
+final class SpecDescriptor extends AbstractTestDescriptor implements ExecutableTestDescriptor {
 	private final Verification verification;
 
 	public static SpecDescriptor of(UniqueId parentId, String behavior, Verification verification) {


### PR DESCRIPTION
Simplify `JavaSpecEngine` by delegating container/test execution to `ExecutableTestDescriptor`, which either executes a spec (test) or all child descriptors (container).