### PR TITLE
Add copyright and license notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -9,8 +9,8 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Kyle Krull
+Copyright (c) 2014-2022 Kyle Krull
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2014-2022 Kyle Krull
+Copyright (c) 2014–2022 Kyle Krull
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/nested-lambdas/buildSrc/build.gradle
+++ b/nested-lambdas/buildSrc/build.gradle
@@ -7,6 +7,7 @@ description 'Conventions for JavaSpec projects'
 dependencies {
 	implementation 'com.adarshr:gradle-test-logger-plugin:3.1.0'
 	implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.3.0'
+	implementation 'com.github.hierynomus.license:com.github.hierynomus.license.gradle.plugin:0.16.1'
 }
 
 repositories {

--- a/nested-lambdas/buildSrc/src/main/groovy/info/javaspec/LicenseConventionExtension.groovy
+++ b/nested-lambdas/buildSrc/src/main/groovy/info/javaspec/LicenseConventionExtension.groovy
@@ -1,0 +1,7 @@
+package info.javaspec
+
+import org.gradle.api.file.RegularFileProperty
+
+interface LicenseConventionExtension {
+	RegularFileProperty getLicenseFile()
+}

--- a/nested-lambdas/buildSrc/src/main/groovy/local.java-format-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.java-format-convention.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 import info.javaspec.JavaFormatConventionExtension
-def extension = project.extensions.create('localJavaFormatConvention', JavaFormatConventionExtension)
+def extension = project.extensions.create('javaFormatConvention', JavaFormatConventionExtension)
 
 //https://github.com/diffplug/spotless/tree/main/plugin-gradle#java
 spotless {

--- a/nested-lambdas/buildSrc/src/main/groovy/local.license-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.license-convention.gradle
@@ -1,0 +1,4 @@
+//Conventions for adding copyright and license notifications to source files
+plugins {
+	id 'com.github.hierynomus.license'
+}

--- a/nested-lambdas/buildSrc/src/main/groovy/local.license-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.license-convention.gradle
@@ -9,6 +9,7 @@ def licenseExtension = project.extensions.create('licenseConvention', LicenseCon
 afterEvaluate {
 	//https://github.com/hierynomus/license-gradle-plugin/tree/v0.16.1
 	license {
+		exclude 'META-INF/services/*'
 		header licenseExtension.licenseFile.get().asFile
 		strictCheck true
 	}

--- a/nested-lambdas/buildSrc/src/main/groovy/local.license-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.license-convention.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 import info.javaspec.LicenseConventionExtension
-def licenseExtension = project.extensions.create('localLicenseConvention', LicenseConventionExtension)
+def licenseExtension = project.extensions.create('licenseConvention', LicenseConventionExtension)
 
 afterEvaluate {
 	//https://github.com/hierynomus/license-gradle-plugin/tree/v0.16.1

--- a/nested-lambdas/buildSrc/src/main/groovy/local.license-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.license-convention.gradle
@@ -2,3 +2,15 @@
 plugins {
 	id 'com.github.hierynomus.license'
 }
+
+import info.javaspec.LicenseConventionExtension
+def licenseExtension = project.extensions.create('localLicenseConvention', LicenseConventionExtension)
+
+afterEvaluate {
+	//https://github.com/hierynomus/license-gradle-plugin/tree/v0.16.1
+	license {
+		header licenseExtension.licenseFile.get().asFile
+		strictCheck true
+	}
+}
+

--- a/nested-lambdas/buildSrc/src/main/groovy/local.license-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.license-convention.gradle
@@ -13,4 +13,3 @@ afterEvaluate {
 		strictCheck true
 	}
 }
-

--- a/nested-lambdas/buildSrc/src/main/groovy/local.maven-publish-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.maven-publish-convention.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 import info.javaspec.MavenPublishConventionExtension
-def extension = project.extensions.create('localMavenPublishConvention', MavenPublishConventionExtension)
+def extension = project.extensions.create('mavenPublishConvention', MavenPublishConventionExtension)
 
 //Support deferred configuration
 //https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:deferred_configuration

--- a/nested-lambdas/doc/developing-javaspec.md
+++ b/nested-lambdas/doc/developing-javaspec.md
@@ -59,7 +59,7 @@ plugins {
 
 localJavaFormatConvention {
   //File that holds the Eclipse Formatter configuration
-  eclipseConfigFile = file('../etc/eclipse-format.xml')
+  eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 }
 ```
 

--- a/nested-lambdas/doc/developing-javaspec.md
+++ b/nested-lambdas/doc/developing-javaspec.md
@@ -58,7 +58,7 @@ plugins {
   id 'local.license-convention'
 }
 
-localLicenseConvention.licenseFile = rootProject.file('../LICENSE')
+licenseConvention.licenseFile = rootProject.file('../LICENSE')
 ```
 
 The [`license-gradle-plugin`][github-license-gradle-plugin] creates and
@@ -88,10 +88,8 @@ plugins {
   id 'local.java-format-convention'
 }
 
-localJavaFormatConvention {
-  //File that holds the Eclipse Formatter configuration
-  eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
-}
+//File that holds the Eclipse Formatter configuration
+javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 ```
 
 The [Spotless plugin][github-diffplug-spotless] creates and configures the
@@ -126,7 +124,7 @@ plugins {
   id 'local.maven-publish-convention'
 }
 
-localMavenPublishConvention {
+mavenPublishConvention {
   publicationDescription = project.description
   publicationFrom = components.java
   publicationName = '<human readable name for your artifact>'

--- a/nested-lambdas/doc/developing-javaspec.md
+++ b/nested-lambdas/doc/developing-javaspec.md
@@ -207,3 +207,42 @@ dependencies {
   testRuntimeOnly project(':jupiter-test-execution-listener')
 }
 ```
+
+
+### Visualize Gradle task dependencies
+
+The [gradle-task-tree plugin][github-gradle-task-tree] can help you visualize
+Gradle task dependencies.  Start by temporarily adding this plugin:
+
+```groovy
+//build.gradle
+plugins {
+  id 'com.dorongold.task-tree' version '2.1.0'
+}
+```
+
+Then run the plugin task, as in the following example:
+
+```shell
+$ ./gradlew <task> taskTree
+$ ./gradlew build taskTree
+:build
++--- :assemble
+|    \--- :jar
+|         \--- :classes
+|              +--- :compileJava
+|              \--- :processResources
+\--- :check
+     \--- :test
+          +--- :classes
+          |    +--- :compileJava
+          |    \--- :processResources
+          \--- :testClasses
+               +--- :compileTestJava
+               |    \--- :classes
+               |         +--- :compileJava
+               |         \--- :processResources
+               \--- :processTestResources
+```
+
+[github-gradle-task-tree]: https://github.com/dorongold/gradle-task-tree

--- a/nested-lambdas/doc/developing-javaspec.md
+++ b/nested-lambdas/doc/developing-javaspec.md
@@ -54,12 +54,12 @@ tasks for validating and fixing the format of Java sources:
 
 ```groovy
 plugins {
-	id 'javaspec.java-format-convention'
+  id 'javaspec.java-format-convention'
 }
 
 localJavaFormatConvention {
   //File that holds the Eclipse Formatter configuration
-	eclipseConfigFile = file('../etc/eclipse-format.xml')
+  eclipseConfigFile = file('../etc/eclipse-format.xml')
 }
 ```
 
@@ -91,13 +91,13 @@ tasks for publishing project artifacts to Maven repositories.
 
 ```groovy
 plugins {
-	id 'javaspec.maven-publish-convention'
+  id 'javaspec.maven-publish-convention'
 }
 
 localMavenPublishConvention {
-	publicationDescription = project.description
-	publicationFrom = components.java
-	publicationName = '<human readable name for your artifact>'
+  publicationDescription = project.description
+  publicationFrom = components.java
+  publicationName = '<human readable name for your artifact>'
 }
 ```
 
@@ -141,7 +141,7 @@ tasks for running automated unit tests.
 
 ```groovy
 plugins {
-	id 'javaspec.java-junit-convention'
+  id 'javaspec.java-junit-convention'
 }
 ```
 

--- a/nested-lambdas/doc/developing-javaspec.md
+++ b/nested-lambdas/doc/developing-javaspec.md
@@ -47,12 +47,43 @@ See sources in `buildSrc/` for details.
 [gradle-custom-plugins]: https://docs.gradle.org/current/userguide/custom_plugins.html#sec:precompiled_plugins
 
 
+## Add license and copyright notices to source files with `license-gradle-plugin`
+
+Add the `local.license-convention` plugin to a project, to add Gradle tasks for
+checking and updating license and copyright headers in source files:
+
+```groovy
+//build.gradle
+plugins {
+  id 'local.license-convention'
+}
+
+localLicenseConvention.licenseFile = rootProject.file('../LICENSE')
+```
+
+The [`license-gradle-plugin`][github-license-gradle-plugin] creates and
+configures Gradle tasks for adding headers to source files, to clarify who owns
+the copyright for each source file and how it may be used.   This adds the
+following tasks:
+
+```shell
+$ ./gradlew check #lifecycle task that also runs licenseCheck
+$ ./gradlew licenseCheck #Make sure source file headers are the same as the LICENSE file
+$ ./gradlew licenseFormat #Re-apply the contents of LICENSE to source file headers
+```
+
+See `buildSrc/local.license-convention.gradle` for details.
+
+[github-license-gradle-plugin]: https://github.com/hierynomus/license-gradle-plugin/tree/v0.16.1
+
+
 ## Format Java sources with Spotless
 
 Add the `javaspec.java-format-convention` plugin to a project, to add Gradle
 tasks for validating and fixing the format of Java sources:
 
 ```groovy
+//build.gradle
 plugins {
   id 'javaspec.java-format-convention'
 }
@@ -90,6 +121,7 @@ Add the `javaspec.maven-publish-convention` plugin to a project, to add Gradle
 tasks for publishing project artifacts to Maven repositories.
 
 ```groovy
+//build.gradle
 plugins {
   id 'javaspec.maven-publish-convention'
 }
@@ -140,6 +172,7 @@ Add the `javaspec.java-junit-convention` plugin to a project, to add Gradle
 tasks for running automated unit tests.
 
 ```groovy
+//build.gradle
 plugins {
   id 'javaspec.java-junit-convention'
 }

--- a/nested-lambdas/doc/developing-javaspec.md
+++ b/nested-lambdas/doc/developing-javaspec.md
@@ -36,7 +36,7 @@ form of [pre-compiled, custom plugins][gradle-custom-plugins].
 
 Much like with the top-level projects themselves, each plugin tries to be as
 independent (and make as few assumptions) as possible.  For example the
-`javaspec.maven-publish-convention` allows you to publish artifacts, without
+`local.maven-publish-convention` allows you to publish artifacts, without
 specifically mandating they be derived from Java sources.
 
 _TL;DR - some configuration is required, in the name of being easier to apply
@@ -79,13 +79,13 @@ See `buildSrc/local.license-convention.gradle` for details.
 
 ## Format Java sources with Spotless
 
-Add the `javaspec.java-format-convention` plugin to a project, to add Gradle
-tasks for validating and fixing the format of Java sources:
+Add the `local.java-format-convention` plugin to a project, to add Gradle tasks
+for validating and fixing the format of Java sources:
 
 ```groovy
 //build.gradle
 plugins {
-  id 'javaspec.java-format-convention'
+  id 'local.java-format-convention'
 }
 
 localJavaFormatConvention {
@@ -109,7 +109,7 @@ $ ./gradlew spotlessCheck #Fail if sources are not format-compliant
 $ ./gradlew spotlessApply #Re-format sources
 ```
 
-See `buildSrc/javaspec.java-format-convention.gradle` for details.
+See `buildSrc/local.java-format-convention.gradle` for details.
 
 [github-diffplug-spotless]: https://github.com/diffplug/spotless
 [github-diffplug-spotless-eclipse]: https://github.com/diffplug/spotless/tree/main/plugin-gradle#eclipse-jdt
@@ -117,13 +117,13 @@ See `buildSrc/javaspec.java-format-convention.gradle` for details.
 
 ## Publish SNAPSHOT jars to Maven Local
 
-Add the `javaspec.maven-publish-convention` plugin to a project, to add Gradle
+Add the `local.maven-publish-convention` plugin to a project, to add Gradle
 tasks for publishing project artifacts to Maven repositories.
 
 ```groovy
 //build.gradle
 plugins {
-  id 'javaspec.maven-publish-convention'
+  id 'local.maven-publish-convention'
 }
 
 localMavenPublishConvention {
@@ -161,20 +161,20 @@ repositories {
 }
 ```
 
-See `buildSrc/javaspec.maven-publish-convention.gradle` for details.
+See `buildSrc/local.maven-publish-convention.gradle` for details.
 
 [gradle-publishing-maven]: https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:complete_example
 
 
 ## Test Java code with the JUnit Platform
 
-Add the `javaspec.java-junit-convention` plugin to a project, to add Gradle
-tasks for running automated unit tests.
+Add the `local.java-junit-convention` plugin to a project, to add Gradle tasks
+for running automated unit tests.
 
 ```groovy
 //build.gradle
 plugins {
-  id 'javaspec.java-junit-convention'
+  id 'local.java-junit-convention'
 }
 ```
 

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -20,25 +20,20 @@ copyrightr {
 	copyrightHolder = 'Kyle Krull'
 
 	// Which files are to be included, by default the included files are
-	// - src/**/*.java, and
-	// - src/**/*.groovy
-	// includes = [
-	// 	"src/**/*.java",
-	// 	"src/**/*.groovy"
-	// ]
+	includes = [
+		"src/**/*.java"
+	]
 
 	// which files are to be excluded, by default there are no exclusions
 	// excludes = [ "**/*.class" ]
 
-	// whether to only replace the first found instance, by default this
-	// is set to true
+	// whether to only replace the first found instance
 	onlyReplaceFirst = true
 
 	// the year separator to use
-	yearSeparator = " - "
+	yearSeparator = "–"
 
-	// Whether to fail the build on any missing copyright notifications, by
-	// default, this is set to false
+	// Whether to fail the build on any missing copyright notifications
 	failOnMissing = false
 }
 

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -9,16 +9,11 @@ description 'Everything needed to declare specs'
 version '2.0.0-SNAPSHOT'
 
 copyrightr {
-	// This will be part of the regular expression that is searched for.
-	// This helps to narrow down the lines that will be updated, useful
-	// where there may be other companies that have copyright information
-	copyrightHolder = 'Kyle Krull'
-
-	// log what would have been changed, or over-write files without warning
+	copyrightHolder = 'Kyle Krull' //Used for search and replacement
 	dryRun = false
-	// excludes = [ "**/*.class" ]
-	failOnMissing = false
+	excludes = []
 
+	failOnMissing = true
 	includes = [
 		"src/**/*.java"
 	]

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java-library'
 	id 'local.java-format-convention'
 	id 'local.maven-publish-convention'
+	id 'synapticloop.copyrightr' version '1.3.1'
 }
 
 description 'Everything needed to declare specs'

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -8,6 +8,40 @@ plugins {
 description 'Everything needed to declare specs'
 version '2.0.0-SNAPSHOT'
 
+copyrightr {
+	// If set to true (default), this will only log what would have been
+	// changed, if set to false, this will over-write the files __without__
+	// warning
+	dryRun = false
+
+	// This will be part of the regular expression that is searched for.
+	// This helps to narrow down the lines that will be updated, useful
+	// where there may be other companies that have copyright information
+	copyrightHolder = 'Kyle Krull'
+
+	// Which files are to be included, by default the included files are
+	// - src/**/*.java, and
+	// - src/**/*.groovy
+	// includes = [
+	// 	"src/**/*.java",
+	// 	"src/**/*.groovy"
+	// ]
+
+	// which files are to be excluded, by default there are no exclusions
+	// excludes = [ "**/*.class" ]
+
+	// whether to only replace the first found instance, by default this
+	// is set to true
+	onlyReplaceFirst = true
+
+	// the year separator to use
+	yearSeparator = " - "
+
+	// Whether to fail the build on any missing copyright notifications, by
+	// default, this is set to false
+	failOnMissing = false
+}
+
 dependencies { }
 
 localJavaFormatConvention {

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -1,9 +1,8 @@
 plugins {
 	id 'java-library'
 	id 'local.java-format-convention'
+	id 'local.license-convention'
 	id 'local.maven-publish-convention'
-	id 'com.github.hierynomus.license' version '0.16.1'
-	id 'com.dorongold.task-tree' version '2.1.0'
 }
 
 description 'Everything needed to declare specs'

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -10,13 +10,12 @@ version '2.0.0-SNAPSHOT'
 
 dependencies { }
 
-license {
-	header rootProject.file('../LICENSE')
-	strictCheck true
-}
-
 localJavaFormatConvention {
 	eclipseConfigFile = file('../etc/eclipse-format.xml')
+}
+
+localLicenseConvention{
+	licenseFile = rootProject.file('../LICENSE')
 }
 
 localMavenPublishConvention {

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -11,7 +11,7 @@ version '2.0.0-SNAPSHOT'
 dependencies { }
 
 localJavaFormatConvention {
-	eclipseConfigFile = file('../etc/eclipse-format.xml')
+	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 }
 
 localLicenseConvention{

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -13,6 +13,7 @@ dependencies { }
 
 license {
 	header rootProject.file('../LICENSE')
+	strictCheck true
 }
 
 localJavaFormatConvention {

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -10,13 +10,9 @@ version '2.0.0-SNAPSHOT'
 
 dependencies { }
 
-localJavaFormatConvention {
-	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
-}
-
-localLicenseConvention.licenseFile = rootProject.file('../LICENSE')
-
-localMavenPublishConvention {
+javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
+licenseConvention.licenseFile = rootProject.file('../LICENSE')
+mavenPublishConvention {
 	publicationDescription = project.description
 	publicationFrom = components.java
 	publicationName = 'JavaSpec API'

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -2,30 +2,18 @@ plugins {
 	id 'java-library'
 	id 'local.java-format-convention'
 	id 'local.maven-publish-convention'
-	id 'synapticloop.copyrightr' version '1.3.1'
+	id 'com.github.hierynomus.license' version '0.16.1'
 	id 'com.dorongold.task-tree' version '2.1.0'
 }
 
 description 'Everything needed to declare specs'
 version '2.0.0-SNAPSHOT'
 
-check.dependsOn('copyrightr')
-
-copyrightr {
-	copyrightHolder = 'Kyle Krull' //Used for search and replacement
-	dryRun = false
-	excludes = []
-
-	failOnMissing = true
-	includes = [
-		"src/**/*.java"
-	]
-
-	onlyReplaceFirst = true
-	yearSeparator = '–'
-}
-
 dependencies { }
+
+license {
+	header rootProject.file('../LICENSE')
+}
 
 localJavaFormatConvention {
 	eclipseConfigFile = file('../etc/eclipse-format.xml')

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -14,9 +14,7 @@ localJavaFormatConvention {
 	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 }
 
-localLicenseConvention{
-	licenseFile = rootProject.file('../LICENSE')
-}
+localLicenseConvention.licenseFile = rootProject.file('../LICENSE')
 
 localMavenPublishConvention {
 	publicationDescription = project.description

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -9,6 +9,8 @@ plugins {
 description 'Everything needed to declare specs'
 version '2.0.0-SNAPSHOT'
 
+check.dependsOn('copyrightr')
+
 copyrightr {
 	copyrightHolder = 'Kyle Krull' //Used for search and replacement
 	dryRun = false

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -9,32 +9,22 @@ description 'Everything needed to declare specs'
 version '2.0.0-SNAPSHOT'
 
 copyrightr {
-	// If set to true (default), this will only log what would have been
-	// changed, if set to false, this will over-write the files __without__
-	// warning
-	dryRun = false
-
 	// This will be part of the regular expression that is searched for.
 	// This helps to narrow down the lines that will be updated, useful
 	// where there may be other companies that have copyright information
 	copyrightHolder = 'Kyle Krull'
 
-	// Which files are to be included, by default the included files are
+	// log what would have been changed, or over-write files without warning
+	dryRun = false
+	// excludes = [ "**/*.class" ]
+	failOnMissing = false
+
 	includes = [
 		"src/**/*.java"
 	]
 
-	// which files are to be excluded, by default there are no exclusions
-	// excludes = [ "**/*.class" ]
-
-	// whether to only replace the first found instance
 	onlyReplaceFirst = true
-
-	// the year separator to use
-	yearSeparator = "–"
-
-	// Whether to fail the build on any missing copyright notifications
-	failOnMissing = false
+	yearSeparator = '–'
 }
 
 dependencies { }

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'local.java-format-convention'
 	id 'local.maven-publish-convention'
 	id 'synapticloop.copyrightr' version '1.3.1'
+	id 'com.dorongold.task-tree' version '2.1.0'
 }
 
 description 'Everything needed to declare specs'

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
@@ -10,8 +10,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
@@ -1,4 +1,7 @@
-/* Copyright (c) 2014–2022 Kyle Krull.  All rights reserved. */
+/*
+ * Copyright (c) 2014–2022 Kyle Krull.
+ * All rights reserved.
+ */
 
 package info.javaspec.api;
 

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
@@ -1,3 +1,5 @@
+/* Copyright (c) 2014–2022 Kyle Krull.  All rights reserved. */
+
 package info.javaspec.api;
 
 //Entrypoint for all syntax used to write specs in JavaSpec

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
@@ -1,8 +1,26 @@
-/*
- * Copyright (c) 2014–2022 Kyle Krull.
- * All rights reserved.
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
-
 package info.javaspec.api;
 
 //Entrypoint for all syntax used to write specs in JavaSpec

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
@@ -1,7 +1,7 @@
 /**
- * The MIT License (MIT)
+ * MIT License
  *
- * Copyright (c) 2014-2022 Kyle Krull
+ * Copyright (c) 2014–2022 Kyle Krull
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
@@ -10,8 +10,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
@@ -1,8 +1,26 @@
-/*
- * Copyright (c) 2014–2022 Kyle Krull.
- * All rights reserved.
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
-
 package info.javaspec.api;
 
 //A class with specs in it

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2014–2022 Kyle Krull.
+ * All rights reserved.
+ */
+
 package info.javaspec.api;
 
 //A class with specs in it

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
@@ -1,7 +1,7 @@
 /**
- * The MIT License (MIT)
+ * MIT License
  *
- * Copyright (c) 2014-2022 Kyle Krull
+ * Copyright (c) 2014–2022 Kyle Krull
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/Verification.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/Verification.java
@@ -10,8 +10,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/Verification.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/Verification.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2014–2022 Kyle Krull.
+ * All rights reserved.
+ */
+
 package info.javaspec.api;
 
 //A procedure that verifies the behavior under test

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/Verification.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/Verification.java
@@ -1,8 +1,26 @@
-/*
- * Copyright (c) 2014–2022 Kyle Krull.
- * All rights reserved.
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
-
 package info.javaspec.api;
 
 //A procedure that verifies the behavior under test

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/Verification.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/Verification.java
@@ -1,7 +1,7 @@
 /**
- * The MIT License (MIT)
+ * MIT License
  *
- * Copyright (c) 2014-2022 Kyle Krull
+ * Copyright (c) 2014–2022 Kyle Krull
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/nested-lambdas/javaspec-client/build.gradle
+++ b/nested-lambdas/javaspec-client/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 }
 
 localJavaFormatConvention {
-	eclipseConfigFile = file('../etc/eclipse-format.xml')
+	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 }
 
 java {

--- a/nested-lambdas/javaspec-client/build.gradle
+++ b/nested-lambdas/javaspec-client/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'local.java-format-convention'
 	id 'local.java-junit-convention'
+	id 'local.license-convention'
 }
 
 description 'Example project that uses JavaSpec for its tests'
@@ -19,6 +20,8 @@ dependencies {
 localJavaFormatConvention {
 	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 }
+
+localLicenseConvention.licenseFile = rootProject.file('../LICENSE')
 
 java {
 	jar {

--- a/nested-lambdas/javaspec-client/build.gradle
+++ b/nested-lambdas/javaspec-client/build.gradle
@@ -17,11 +17,8 @@ dependencies {
 //  testRuntimeOnly project(':jupiter-test-execution-listener')
 }
 
-localJavaFormatConvention {
-	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
-}
-
-localLicenseConvention.licenseFile = rootProject.file('../LICENSE')
+javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
+licenseConvention.licenseFile = rootProject.file('../LICENSE')
 
 java {
 	jar {

--- a/nested-lambdas/javaspec-client/src/main/java/info/javaspec/client/GameState.java
+++ b/nested-lambdas/javaspec-client/src/main/java/info/javaspec/client/GameState.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.client;
 
 import java.util.List;

--- a/nested-lambdas/javaspec-client/src/main/java/info/javaspec/client/Greeter.java
+++ b/nested-lambdas/javaspec-client/src/main/java/info/javaspec/client/Greeter.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.client;
 
 public class Greeter {

--- a/nested-lambdas/javaspec-client/src/main/java/info/javaspec/client/Minimax.java
+++ b/nested-lambdas/javaspec-client/src/main/java/info/javaspec/client/Minimax.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.client;
 
 public class Minimax {

--- a/nested-lambdas/javaspec-client/src/test/java/info/javaspec/client/GreeterSpecs.java
+++ b/nested-lambdas/javaspec-client/src/test/java/info/javaspec/client/GreeterSpecs.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/nested-lambdas/javaspec-client/src/test/java/info/javaspec/client/GreeterTest.java
+++ b/nested-lambdas/javaspec-client/src/test/java/info/javaspec/client/GreeterTest.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/nested-lambdas/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
+++ b/nested-lambdas/javaspec-client/src/test/java/info/javaspec/client/MinimaxSpecs.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.client;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/nested-lambdas/javaspec-engine-discovery-request-listener/build.gradle
+++ b/nested-lambdas/javaspec-engine-discovery-request-listener/build.gradle
@@ -12,8 +12,5 @@ dependencies {
 	implementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
-localJavaFormatConvention {
-	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
-}
-
-localLicenseConvention.licenseFile = rootProject.file('../LICENSE')
+javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
+licenseConvention.licenseFile = rootProject.file('../LICENSE')

--- a/nested-lambdas/javaspec-engine-discovery-request-listener/build.gradle
+++ b/nested-lambdas/javaspec-engine-discovery-request-listener/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'java-library'
 	id 'local.java-format-convention'
+	id 'local.license-convention'
 }
 
 description 'Service Provider: an EngineDiscoveryRequestListener that reports DiscoveryRequests to the console'
@@ -14,3 +15,5 @@ dependencies {
 localJavaFormatConvention {
 	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 }
+
+localLicenseConvention.licenseFile = rootProject.file('../LICENSE')

--- a/nested-lambdas/javaspec-engine-discovery-request-listener/build.gradle
+++ b/nested-lambdas/javaspec-engine-discovery-request-listener/build.gradle
@@ -12,5 +12,5 @@ dependencies {
 }
 
 localJavaFormatConvention {
-	eclipseConfigFile = file('../etc/eclipse-format.xml')
+	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 }

--- a/nested-lambdas/javaspec-engine-discovery-request-listener/src/main/java/info/javaspec/engine/ConsoleEngineDiscoveryRequestListener.java
+++ b/nested-lambdas/javaspec-engine-discovery-request-listener/src/main/java/info/javaspec/engine/ConsoleEngineDiscoveryRequestListener.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import org.junit.platform.engine.EngineDiscoveryRequest;

--- a/nested-lambdas/javaspec-engine/build.gradle
+++ b/nested-lambdas/javaspec-engine/build.gradle
@@ -26,13 +26,9 @@ dependencies {
 //  testRuntimeOnly project(':javaspec-engine-discovery-request-listener')
 }
 
-localJavaFormatConvention {
-	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
-}
-
-localLicenseConvention.licenseFile = rootProject.file('../LICENSE')
-
-localMavenPublishConvention {
+javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
+licenseConvention.licenseFile = rootProject.file('../LICENSE')
+mavenPublishConvention {
 	publicationDescription = project.description
 	publicationFrom = components.java
 	publicationName = 'JavaSpec Engine'

--- a/nested-lambdas/javaspec-engine/build.gradle
+++ b/nested-lambdas/javaspec-engine/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java-library'
 	id 'local.java-format-convention'
 	id 'local.java-junit-convention'
+	id 'local.license-convention'
 	id 'local.maven-publish-convention'
 }
 
@@ -28,6 +29,8 @@ dependencies {
 localJavaFormatConvention {
 	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 }
+
+localLicenseConvention.licenseFile = rootProject.file('../LICENSE')
 
 localMavenPublishConvention {
 	publicationDescription = project.description

--- a/nested-lambdas/javaspec-engine/build.gradle
+++ b/nested-lambdas/javaspec-engine/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 localJavaFormatConvention {
-	eclipseConfigFile = file('../etc/eclipse-format.xml')
+	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 }
 
 localMavenPublishConvention {

--- a/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/ContextDescriptor.java
+++ b/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/ContextDescriptor.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import info.javaspec.api.SpecClass;

--- a/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/EngineDiscoveryRequestListener.java
+++ b/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/EngineDiscoveryRequestListener.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import org.junit.platform.engine.EngineDiscoveryRequest;

--- a/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/EngineDiscoveryRequestListenerProvider.java
+++ b/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/EngineDiscoveryRequestListenerProvider.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import java.util.Optional;

--- a/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/ExecutableTestDescriptor.java
+++ b/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/ExecutableTestDescriptor.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import org.junit.platform.engine.EngineExecutionListener;

--- a/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import java.util.Optional;

--- a/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/SkippedSpecDescriptor.java
+++ b/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/SkippedSpecDescriptor.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import org.junit.platform.engine.EngineExecutionListener;

--- a/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDeclaration.java
+++ b/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDeclaration.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import info.javaspec.api.JavaSpec;

--- a/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/SpecDescriptor.java
+++ b/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/SpecDescriptor.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import info.javaspec.api.Verification;

--- a/nested-lambdas/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
+++ b/nested-lambdas/javaspec-engine/src/test/java/info/javaspec/engine/AnonymousSpecClasses.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/nested-lambdas/javaspec-engine/src/test/java/info/javaspec/engine/ConfigurationParametersFactory.java
+++ b/nested-lambdas/javaspec-engine/src/test/java/info/javaspec/engine/ConfigurationParametersFactory.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import java.util.Optional;

--- a/nested-lambdas/javaspec-engine/src/test/java/info/javaspec/engine/DiscoverySelectorFactory.java
+++ b/nested-lambdas/javaspec-engine/src/test/java/info/javaspec/engine/DiscoverySelectorFactory.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import org.junit.platform.engine.DiscoverySelector;

--- a/nested-lambdas/javaspec-engine/src/test/java/info/javaspec/engine/EngineDiscoveryRequestFactory.java
+++ b/nested-lambdas/javaspec-engine/src/test/java/info/javaspec/engine/EngineDiscoveryRequestFactory.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import static info.javaspec.engine.ConfigurationParametersFactory.nullConfigurationParameters;

--- a/nested-lambdas/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
+++ b/nested-lambdas/javaspec-engine/src/test/java/info/javaspec/engine/JavaSpecEngineTest.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import static info.javaspec.engine.DiscoverySelectorFactory.nullDiscoverySelector;

--- a/nested-lambdas/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
+++ b/nested-lambdas/javaspec-engine/src/test/java/info/javaspec/engine/TestDescriptorAssert.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.engine;
 
 import java.util.Collections;

--- a/nested-lambdas/jupiter-test-execution-listener/build.gradle
+++ b/nested-lambdas/jupiter-test-execution-listener/build.gradle
@@ -11,5 +11,5 @@ dependencies {
 }
 
 localJavaFormatConvention {
-	eclipseConfigFile = file('../etc/eclipse-format.xml')
+	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 }

--- a/nested-lambdas/jupiter-test-execution-listener/build.gradle
+++ b/nested-lambdas/jupiter-test-execution-listener/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'java-library'
 	id 'local.java-format-convention'
+	id 'local.license-convention'
 }
 
 description 'Service Provider: a TestExecutionListener that reports test execution events to the console'
@@ -13,3 +14,5 @@ dependencies {
 localJavaFormatConvention {
 	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 }
+
+localLicenseConvention.licenseFile = rootProject.file('../LICENSE')

--- a/nested-lambdas/jupiter-test-execution-listener/build.gradle
+++ b/nested-lambdas/jupiter-test-execution-listener/build.gradle
@@ -11,8 +11,5 @@ dependencies {
 	implementation 'org.junit.platform:junit-platform-launcher:1.8.1'
 }
 
-localJavaFormatConvention {
-	eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
-}
-
-localLicenseConvention.licenseFile = rootProject.file('../LICENSE')
+javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
+licenseConvention.licenseFile = rootProject.file('../LICENSE')

--- a/nested-lambdas/jupiter-test-execution-listener/src/main/java/info/javaspec/jupiter/ConsoleTestExecutionListener.java
+++ b/nested-lambdas/jupiter-test-execution-listener/src/main/java/info/javaspec/jupiter/ConsoleTestExecutionListener.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.jupiter;
 
 import org.junit.platform.engine.TestExecutionResult;


### PR DESCRIPTION
Add headers to each source file that clarifies the copyright owner and the license that governs its use.

While the license need only be included with the source once, it's easier to just have the license-gradle-plugin consume from the same `LICENSE` file that is already in the repository.

Also updated some Gradle configuration for the conventional plugins, so they don't all start with `local`.