### PR TITLE
Generate snapshot artifacts

### DIFF
--- a/nested-lambdas/build.gradle
+++ b/nested-lambdas/build.gradle
@@ -1,5 +1,7 @@
 description 'JavaSpec 2.x'
 
+
+//TODO KDK: Make sure LICENSE gets included in the jar files under META-INF
 subprojects {
 	group 'info.javaspec'
 

--- a/nested-lambdas/build.gradle
+++ b/nested-lambdas/build.gradle
@@ -1,7 +1,5 @@
 description 'JavaSpec 2.x'
 
-
-//TODO KDK: Make sure LICENSE gets included in the jar files under META-INF
 subprojects {
 	group 'info.javaspec'
 

--- a/nested-lambdas/buildSrc/src/main/groovy/info/javaspec/JarConventionExtension.groovy
+++ b/nested-lambdas/buildSrc/src/main/groovy/info/javaspec/JarConventionExtension.groovy
@@ -1,0 +1,7 @@
+package info.javaspec
+
+import org.gradle.api.file.RegularFileProperty
+
+interface JarConventionExtension {
+	RegularFileProperty getLicenseFile()
+}

--- a/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
@@ -10,6 +10,7 @@ afterEvaluate {
 	java {
 		tasks.named('javadoc', Javadoc) {
 			options.addStringOption('link', 'https://docs.oracle.com/javase/8/docs/api')
+			options.addStringOption('link', 'https://junit.org/junit5/docs/current/api/')
 			options.addStringOption('source', '1.8')
 		}
 

--- a/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
@@ -7,9 +7,11 @@ import info.javaspec.JarConventionExtension
 def extension = project.extensions.create('jarConvention', JarConventionExtension)
 
 afterEvaluate {
-	jar {
-		into('META-INF') {
-			from extension.licenseFile.get().asFile
+	java {
+		jar {
+			into('META-INF') {
+				from extension.licenseFile.get().asFile
+			}
 		}
 	}
 }

--- a/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
@@ -3,6 +3,11 @@ plugins {
 	id 'java'
 }
 
-jar {
-	from '../../LICENSE'
+import info.javaspec.JarConventionExtension
+def extension = project.extensions.create('jarConvention', JarConventionExtension)
+
+afterEvaluate {
+	jar {
+		from extension.licenseFile.get().asFile
+	}
 }

--- a/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
@@ -8,6 +8,8 @@ def extension = project.extensions.create('jarConvention', JarConventionExtensio
 
 afterEvaluate {
 	jar {
-		from extension.licenseFile.get().asFile
+		into('META-INF') {
+			from extension.licenseFile.get().asFile
+		}
 	}
 }

--- a/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
@@ -14,7 +14,15 @@ afterEvaluate {
 			}
 		}
 
-		//Build a -sources jar too, including a standalone license file
+		//Build a -javadoc jar too, adding a standalone license file
+		withJavadocJar()
+		tasks.named('javadocJar') {
+			into('META-INF') {
+				from extension.licenseFile.get().asFile
+			}
+		}
+
+		//Build a -sources jar too, adding a standalone license file
 		withSourcesJar()
 		tasks.named('sourcesJar') {
 			into('META-INF') {

--- a/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
@@ -13,5 +13,7 @@ afterEvaluate {
 				from extension.licenseFile.get().asFile
 			}
 		}
+
+		withSourcesJar()
 	}
 }

--- a/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
@@ -14,12 +14,12 @@ afterEvaluate {
 			}
 		}
 
+		//Build a -sources jar too, including a standalone license file
 		withSourcesJar()
-	}
-
-	tasks.named('sourcesJar') {
-		into('META-INF') {
-			from extension.licenseFile.get().asFile
+		tasks.named('sourcesJar') {
+			into('META-INF') {
+				from extension.licenseFile.get().asFile
+			}
 		}
 	}
 }

--- a/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
@@ -16,4 +16,10 @@ afterEvaluate {
 
 		withSourcesJar()
 	}
+
+	tasks.named('sourcesJar') {
+		into('META-INF') {
+			from extension.licenseFile.get().asFile
+		}
+	}
 }

--- a/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
@@ -1,0 +1,8 @@
+//Conventions for publishing artifacts as JARs
+plugins {
+	id 'java'
+}
+
+jar {
+	from '../../LICENSE'
+}

--- a/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
@@ -8,6 +8,11 @@ def extension = project.extensions.create('jarConvention', JarConventionExtensio
 
 afterEvaluate {
 	java {
+		tasks.named('javadoc', Javadoc) {
+			options.addStringOption('link', 'https://docs.oracle.com/javase/8/docs/api')
+			options.addStringOption('source', '1.8')
+		}
+
 		jar {
 			into('META-INF') {
 				from extension.licenseFile.get().asFile

--- a/nested-lambdas/buildSrc/src/main/groovy/local.maven-publish-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.maven-publish-convention.gradle
@@ -22,6 +22,7 @@ afterEvaluate {
 					developers {
 						developer {
 							id = 'kkrull'
+							email = 'kdkrull@gmail.com'
 							name = 'Kyle Krull'
 						}
 					}
@@ -29,6 +30,13 @@ afterEvaluate {
 					issueManagement {
 						system = 'GitHub'
 						url = 'https://github.com/kkrull/javaspec/issues'
+					}
+
+					licenses {
+						license {
+							name = 'MIT license'
+							url = 'https://spdx.org/licenses/MIT'
+						}
 					}
 
 					scm {

--- a/nested-lambdas/doc/developing-javaspec.md
+++ b/nested-lambdas/doc/developing-javaspec.md
@@ -47,7 +47,52 @@ See sources in `buildSrc/` for details.
 [gradle-custom-plugins]: https://docs.gradle.org/current/userguide/custom_plugins.html#sec:precompiled_plugins
 
 
-## Add license and copyright notices to source files with `license-gradle-plugin`
+### Visualize task dependencies
+
+If you're getting lost in which tasks trigger each other, the
+[gradle-task-tree plugin][github-gradle-task-tree] can help.  Start by
+temporarily adding this plugin:
+
+```groovy
+//build.gradle
+plugins {
+  id 'com.dorongold.task-tree' version '2.1.0'
+}
+```
+
+Then run the plugin task, as in the following example:
+
+```shell
+$ ./gradlew <task> taskTree
+$ ./gradlew build taskTree
+:build
++--- :assemble
+|    \--- :jar
+|         \--- :classes
+|              +--- :compileJava
+|              \--- :processResources
+\--- :check
+     \--- :test
+          +--- :classes
+          |    +--- :compileJava
+          |    \--- :processResources
+          \--- :testClasses
+               +--- :compileTestJava
+               |    \--- :classes
+               |         +--- :compileJava
+               |         \--- :processResources
+               \--- :processTestResources
+```
+
+[github-gradle-task-tree]: https://github.com/dorongold/gradle-task-tree
+
+
+## Common Development Tasks
+
+Gradle has tasks to handle many of the things you need to do as a developer.
+
+
+### Add license and copyright notices with `license-gradle-plugin`
 
 Add the `local.license-convention` plugin to a project, to add Gradle tasks for
 checking and updating license and copyright headers in source files:
@@ -94,7 +139,7 @@ See `buildSrc/local.license-convention.gradle` for details.
 [github-license-gradle-plugin]: https://github.com/hierynomus/license-gradle-plugin/tree/v0.16.1
 
 
-## Assemble JARs with Gradle
+### Assemble JARs
 
 Add the `local.jar-convention` plugin to a project, to configure Gradle tasks
 for building JAR artifacts that you need when deploying to the Maven Central
@@ -128,7 +173,7 @@ See `buildSrc/local.jar-convention.gradle` for details.
 [gradle-bundling]: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Jar.html
 
 
-## Format Java sources with Spotless
+### Format Java sources with Spotless
 
 Add the `local.java-format-convention` plugin to a project, to add Gradle tasks
 for validating and fixing the format of Java sources:
@@ -164,7 +209,7 @@ See `buildSrc/local.java-format-convention.gradle` for details.
 [github-diffplug-spotless-eclipse]: https://github.com/diffplug/spotless/tree/main/plugin-gradle#eclipse-jdt
 
 
-## Publish SNAPSHOT jars to Maven Local
+### Publish SNAPSHOT jars to Maven Local
 
 Add the `local.maven-publish-convention` plugin to a project, to add Gradle
 tasks for publishing project artifacts to Maven repositories.
@@ -216,7 +261,7 @@ See `buildSrc/local.maven-publish-convention.gradle` for details.
 [gradle-publishing-maven]: https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:complete_example
 
 
-## Test Java code with the JUnit Platform
+### Test Java code with the JUnit Platform
 
 Add the `local.java-junit-convention` plugin to a project, to add Gradle tasks
 for running automated unit tests.
@@ -251,6 +296,12 @@ $ ./gradlew -Dtestlogger.theme=plain test
 
 [github-gradle-test-logger]: https://github.com/radarsh/gradle-test-logger-plugin
 [gradle-java-testing]: https://docs.gradle.org/current/userguide/java_testing.html
+
+
+## Debugging Tools
+
+There are some tools that can help to understand how JavaSpec is running under
+the JUnit Platform, if you get stuck.
 
 
 ### Log a `DiscoveryRequest` with `javaspec-engine-discovery-request-listener`
@@ -290,42 +341,3 @@ dependencies {
   testRuntimeOnly project(':jupiter-test-execution-listener')
 }
 ```
-
-
-### Visualize Gradle task dependencies
-
-The [gradle-task-tree plugin][github-gradle-task-tree] can help you visualize
-Gradle task dependencies.  Start by temporarily adding this plugin:
-
-```groovy
-//build.gradle
-plugins {
-  id 'com.dorongold.task-tree' version '2.1.0'
-}
-```
-
-Then run the plugin task, as in the following example:
-
-```shell
-$ ./gradlew <task> taskTree
-$ ./gradlew build taskTree
-:build
-+--- :assemble
-|    \--- :jar
-|         \--- :classes
-|              +--- :compileJava
-|              \--- :processResources
-\--- :check
-     \--- :test
-          +--- :classes
-          |    +--- :compileJava
-          |    \--- :processResources
-          \--- :testClasses
-               +--- :compileTestJava
-               |    \--- :classes
-               |         +--- :compileJava
-               |         \--- :processResources
-               \--- :processTestResources
-```
-
-[github-gradle-task-tree]: https://github.com/dorongold/gradle-task-tree

--- a/nested-lambdas/doc/developing-javaspec.md
+++ b/nested-lambdas/doc/developing-javaspec.md
@@ -63,12 +63,29 @@ licenseConvention.licenseFile = rootProject.file('../LICENSE')
 
 The [`license-gradle-plugin`][github-license-gradle-plugin] creates and
 configures Gradle tasks for adding headers to source files, to clarify who owns
-the copyright for each source file and how it may be used.   This adds the
-following tasks:
+the copyright for each source file and how it may be used.   This adds a task
+that parses source files to make sure they all have the same license header that
+is in the given `LICENSE` file.
 
 ```shell
 $ ./gradlew check #lifecycle task that also runs licenseCheck
 $ ./gradlew licenseCheck #Make sure source file headers are the same as the LICENSE file
+
+#Example output when something goes wrong
+Missing header in: javaspec-api/src/main/java/info/javaspec/api/BehaviorDeclaration.java
+> Task :javaspec-api:licenseMain FAILED
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':javaspec-api:licenseMain'.
+> License violations were found: javaspec-api/src/main/java/info/javaspec/api/BehaviorDeclaration.java}
+```
+
+There is also a Gradle task to add (or correct) the appropriate headers to
+source files:
+
+```shell
 $ ./gradlew licenseFormat #Re-apply the contents of LICENSE to source file headers
 ```
 

--- a/nested-lambdas/doc/developing-javaspec.md
+++ b/nested-lambdas/doc/developing-javaspec.md
@@ -80,8 +80,8 @@ See `buildSrc/local.license-convention.gradle` for details.
 ## Assemble JARs with Gradle
 
 Add the `local.jar-convention` plugin to a project, to configure Gradle tasks
-for building JAR artifacts.  Specifically, published artifacts need to include
-the license and copyright notices that are included in this repository.
+for building JAR artifacts that you need when deploying to the Maven Central
+Repository.
 
 ```groovy
 //build.gradle
@@ -92,13 +92,18 @@ plugins {
 jarConvention.licenseFile = rootProject.file('../LICENSE')
 ```
 
+This includes the customary JAR with compiled code, along with `-javadoc` and
+`-sources` JARs that contain Javadoc and raw sources, respectively.  Each
+published artifact also includes the license and copyright notices that are in
+this repository.
+
 The [`jar task`][gradle-bundling] builds JAR files like normal, adding the
 additional files that are required for the convention.  Use the task like you
 always would:
 
 ```shell
 $ ./gradlew assemble #Build artifacts for each project
-$ jar tf build/libs/<.jar file> #Should include LICENSE file
+$ jar tf build/libs/<.jar file> #Should include a META-INF/LICENSE file
 ```
 
 See `buildSrc/local.jar-convention.gradle` for details.

--- a/nested-lambdas/doc/developing-javaspec.md
+++ b/nested-lambdas/doc/developing-javaspec.md
@@ -131,12 +131,13 @@ mavenPublishConvention {
 }
 ```
 
-The [Maven Publish plugin][gradle-publishing-maven] provides the Maven tasks to
-do things like generate POM files and push to Maven repositories.  Each project
-that wishes to publish an artifact does so by creating a single `maven`
-publication.  The `maven-publish` plugin therefore has several tasks with the
-word `Maven` in it, that are meant for that sole publication.  There are also
-aggregator tasks with fixed names, that process all publications.
+The [Maven Publish plugin [for Gradle]][gradle-publishing-maven] provides the
+Gradle tasks to do things like generate POM files and push to Maven
+repositories.  Each project that wishes to publish an artifact does so by
+creating a single `maven` publication.  The `maven-publish` plugin therefore has
+several tasks with the word `Maven` in it, that are meant for that sole
+publication.  There are also aggregator tasks with fixed names, that process all
+publications.
 
 For example:
 

--- a/nested-lambdas/doc/developing-javaspec.md
+++ b/nested-lambdas/doc/developing-javaspec.md
@@ -77,6 +77,35 @@ See `buildSrc/local.license-convention.gradle` for details.
 [github-license-gradle-plugin]: https://github.com/hierynomus/license-gradle-plugin/tree/v0.16.1
 
 
+## Assemble JARs with Gradle
+
+Add the `local.jar-convention` plugin to a project, to configure Gradle tasks
+for building JAR artifacts.  Specifically, published artifacts need to include
+the license and copyright notices that are included in this repository.
+
+```groovy
+//build.gradle
+plugins {
+  id 'local.jar-convention'
+}
+
+jarConvention.licenseFile = rootProject.file('../LICENSE')
+```
+
+The [`jar task`][gradle-bundling] builds JAR files like normal, adding the
+additional files that are required for the convention.  Use the task like you
+always would:
+
+```shell
+$ ./gradlew assemble #Build artifacts for each project
+$ jar tf build/libs/<.jar file> #Should include LICENSE file
+```
+
+See `buildSrc/local.jar-convention.gradle` for details.
+
+[gradle-bundling]: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Jar.html
+
+
 ## Format Java sources with Spotless
 
 Add the `local.java-format-convention` plugin to a project, to add Gradle tasks

--- a/nested-lambdas/etc/git-hooks/pre-commit
+++ b/nested-lambdas/etc/git-hooks/pre-commit
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-# Redirect output to stderr.
+set -e
+
+# Redirect output to stderr
 exec 1>&2
 
 checkCodeFormat() {

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -17,3 +17,7 @@ mavenPublishConvention {
 	publicationFrom = components.java
 	publicationName = 'JavaSpec API'
 }
+
+jar {
+	from '../../LICENSE'
+}

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java-library'
+	id 'local.jar-convention'
 	id 'local.java-format-convention'
 	id 'local.license-convention'
 	id 'local.maven-publish-convention'
@@ -11,10 +12,6 @@ version '2.0.0-SNAPSHOT'
 dependencies { }
 
 javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
-
-jar {
-	from '../../LICENSE'
-}
 
 licenseConvention.licenseFile = rootProject.file('../LICENSE')
 

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -11,6 +11,8 @@ version '2.0.0-SNAPSHOT'
 
 dependencies { }
 
+jarConvention.licenseFile = rootProject.file('../LICENSE')
+
 javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 
 licenseConvention.licenseFile = rootProject.file('../LICENSE')

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -11,13 +11,15 @@ version '2.0.0-SNAPSHOT'
 dependencies { }
 
 javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
+
+jar {
+	from '../../LICENSE'
+}
+
 licenseConvention.licenseFile = rootProject.file('../LICENSE')
+
 mavenPublishConvention {
 	publicationDescription = project.description
 	publicationFrom = components.java
 	publicationName = 'JavaSpec API'
-}
-
-jar {
-	from '../../LICENSE'
 }

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -13,6 +13,10 @@ dependencies { }
 
 jarConvention.licenseFile = rootProject.file('../LICENSE')
 
+java {
+	withSourcesJar()
+}
+
 javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 
 licenseConvention.licenseFile = rootProject.file('../LICENSE')

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -13,10 +13,6 @@ dependencies { }
 
 jarConvention.licenseFile = rootProject.file('../LICENSE')
 
-java {
-	withSourcesJar()
-}
-
 javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
 
 licenseConvention.licenseFile = rootProject.file('../LICENSE')

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/BehaviorDeclaration.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/BehaviorDeclaration.java
@@ -1,3 +1,26 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2014–2022 Kyle Krull
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package info.javaspec.api;
 
 /**

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/BehaviorDeclaration.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/BehaviorDeclaration.java
@@ -1,0 +1,14 @@
+package info.javaspec.api;
+
+/**
+ * A lambda with specs that are related to each other, or more containers. Call
+ * {@link JavaSpec#it(String, Verification)} inside of this.
+ */
+@FunctionalInterface
+public interface BehaviorDeclaration {
+	/**
+	 * A lambda with specs that are related to each other, or more containers. Call
+	 * {@link JavaSpec#it(String, Verification)} inside of this.
+	 */
+	void declare();
+}

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
@@ -112,17 +112,4 @@ public interface JavaSpec {
 	 *                           fixing something else right now.
 	 */
 	void skip(String intendedBehavior, Verification brokenVerification);
-
-	/**
-	 * A lambda with specs that are related to each other, or more containers. Call
-	 * {@link JavaSpec#it(String, Verification)} inside of this.
-	 */
-	@FunctionalInterface
-	interface BehaviorDeclaration {
-		/**
-		 * A lambda with specs that are related to each other, or more containers. Call
-		 * {@link JavaSpec#it(String, Verification)} inside of this.
-		 */
-		void declare();
-	}
 }

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
@@ -23,7 +23,7 @@
  */
 package info.javaspec.api;
 
-//Entrypoint for all syntax used to write specs in JavaSpec
+/** Entrypoint for all syntax used to write specs in JavaSpec */
 public interface JavaSpec {
 	// Context
 	void describe(Class<?> aClass, BehaviorDeclaration declaration);
@@ -35,6 +35,9 @@ public interface JavaSpec {
 	void pending(String futureBehavior);
 	void skip(String intendedBehavior, Verification brokenVerification);
 
+	/**
+	 * A lambda containing specs that are related to each other, or more containers
+	 */
 	@FunctionalInterface
 	interface BehaviorDeclaration {
 		void declare();

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
@@ -23,20 +23,96 @@
  */
 package info.javaspec.api;
 
-/** Entrypoint for all syntax used to write specs in JavaSpec */
+/**
+ * The JavaSpec syntax used to write and organize specs.
+ *
+ * Start by describing a class {@link #describe(Class, BehaviorDeclaration)} or
+ * any subject in general {@link #describe(String, BehaviorDeclaration)}, then
+ * add 1 or more specifications inside of that block with
+ * {@link #it(String, Verification)}.
+ *
+ * Use {@link #pending(String)} or {@link #skip(String, Verification)} for any
+ * specs that you are not ready to run yet, and additional
+ * {@link #describe(String, BehaviorDeclaration)} and
+ * {@link #given(String, BehaviorDeclaration)} containers to organize specs, as
+ * desired.
+ */
 public interface JavaSpec {
-	// Context
+	/* Context */
+
+	/**
+	 * Creates a container that describes a class, resulting in a JUnit test
+	 * container named after the given class.
+	 *
+	 * @param aClass The [production] class to describe.
+	 * @param declaration The lambda declaring specs with
+	 * {@link #it(String, Verification)} and the like.
+	 */
 	void describe(Class<?> aClass, BehaviorDeclaration declaration);
+
+	/**
+	 * Creates a container that describes any generic subject, resulting in a
+	 * JUnit test container with the given string.
+	 *
+	 * @param what The subject or system under test that you are describing.
+	 * @param declaration The lambda declaring specs with
+	 * {@link #it(String, Verification)} and the like.
+	 */
 	void describe(String what, BehaviorDeclaration declaration);
+
+	/**
+	 * Create a specialized container that describes some subject's behavior,
+	 * given some input or precondition.  This results in a JUnit test container
+	 * with the word "given" pre-pended to the given string.
+	 *
+	 * @param what The input or pre-condition that has its own, specific behavior
+	 * @param declaration The lambda declaring specs that define behavior _under
+	 * the given pre-condition_ (or _with the given input_) with
+	 * {@link #it(String, Verification)} and the like.
+	 */
 	void given(String what, BehaviorDeclaration declaration);
 
-	// Specs
+	/* Specs */
+
+	/**
+	 * Declare a specification (spec) that describes and verifies how the subject
+	 * should behave.  Results in a regular JUnit test in the container(s) in the
+	 * surrounding context blocks.
+	 *
+	 * @param behavior A description of what the subject is supposed to do, under
+	 * the circumstances described in any surrounding context blocks.
+	 * @param verification A lambda that contains the test / specification itself
+	 * in the typical Arrange-Act-Assert pattern.
+	 */
 	void it(String behavior, Verification verification);
+
+	/**
+	 * Declare a spec that you're not ready to implement yet, so you remember to
+	 * think about it later.  Results in a disabled (skipped) JUnit test.
+	 *
+	 * @param futureBehavior A description of some behavior you think the subject
+	 * should have in the near future, except that you need to do something else
+	 * right now.
+	 */
 	void pending(String futureBehavior);
+
+	/**
+	 * Declare a spec that should work, if only you could finish the thought and
+	 * complete the verification or fix the bug that is causing the spec to fail.
+	 * Results in a disabled (skipped) JUnit test.
+	 *
+	 * @param intendedBehavior A description of some behavior the subject was
+	 * already supposed to have, except something went wrong and you have to do
+	 * something else right now.
+	 * @param brokenVerification A lambda that contains the test in the typical
+	 * Arrange-Act-Assert pattern, except it's broken and you need to disable it
+	 * long enough to focus on fixing something else right now.
+	 */
 	void skip(String intendedBehavior, Verification brokenVerification);
 
 	/**
-	 * A lambda containing specs that are related to each other, or more containers
+	 * A lambda with specs that are related to each other, or more containers.
+	 * Call {@link JavaSpec#it(String, Verification)} inside of this.
 	 */
 	@FunctionalInterface
 	interface BehaviorDeclaration {

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/JavaSpec.java
@@ -44,31 +44,32 @@ public interface JavaSpec {
 	 * Creates a container that describes a class, resulting in a JUnit test
 	 * container named after the given class.
 	 *
-	 * @param aClass The [production] class to describe.
+	 * @param aClass      The [production] class to describe.
 	 * @param declaration The lambda declaring specs with
-	 * {@link #it(String, Verification)} and the like.
+	 *                    {@link #it(String, Verification)} and the like.
 	 */
 	void describe(Class<?> aClass, BehaviorDeclaration declaration);
 
 	/**
-	 * Creates a container that describes any generic subject, resulting in a
-	 * JUnit test container with the given string.
+	 * Creates a container that describes any generic subject, resulting in a JUnit
+	 * test container with the given string.
 	 *
-	 * @param what The subject or system under test that you are describing.
+	 * @param what        The subject or system under test that you are describing.
 	 * @param declaration The lambda declaring specs with
-	 * {@link #it(String, Verification)} and the like.
+	 *                    {@link #it(String, Verification)} and the like.
 	 */
 	void describe(String what, BehaviorDeclaration declaration);
 
 	/**
-	 * Create a specialized container that describes some subject's behavior,
-	 * given some input or precondition.  This results in a JUnit test container
-	 * with the word "given" pre-pended to the given string.
+	 * Create a specialized container that describes some subject's behavior, given
+	 * some input or precondition. This results in a JUnit test container with the
+	 * word "given" pre-pended to the given string.
 	 *
-	 * @param what The input or pre-condition that has its own, specific behavior
-	 * @param declaration The lambda declaring specs that define behavior _under
-	 * the given pre-condition_ (or _with the given input_) with
-	 * {@link #it(String, Verification)} and the like.
+	 * @param what        The input or pre-condition that has its own, specific
+	 *                    behavior
+	 * @param declaration The lambda declaring specs that define behavior _under the
+	 *                    given pre-condition_ (or _with the given input_) with
+	 *                    {@link #it(String, Verification)} and the like.
 	 */
 	void given(String what, BehaviorDeclaration declaration);
 
@@ -76,23 +77,24 @@ public interface JavaSpec {
 
 	/**
 	 * Declare a specification (spec) that describes and verifies how the subject
-	 * should behave.  Results in a regular JUnit test in the container(s) in the
+	 * should behave. Results in a regular JUnit test in the container(s) in the
 	 * surrounding context blocks.
 	 *
-	 * @param behavior A description of what the subject is supposed to do, under
-	 * the circumstances described in any surrounding context blocks.
-	 * @param verification A lambda that contains the test / specification itself
-	 * in the typical Arrange-Act-Assert pattern.
+	 * @param behavior     A description of what the subject is supposed to do,
+	 *                     under the circumstances described in any surrounding
+	 *                     context blocks.
+	 * @param verification A lambda that contains the test / specification itself in
+	 *                     the typical Arrange-Act-Assert pattern.
 	 */
 	void it(String behavior, Verification verification);
 
 	/**
 	 * Declare a spec that you're not ready to implement yet, so you remember to
-	 * think about it later.  Results in a disabled (skipped) JUnit test.
+	 * think about it later. Results in a disabled (skipped) JUnit test.
 	 *
 	 * @param futureBehavior A description of some behavior you think the subject
-	 * should have in the near future, except that you need to do something else
-	 * right now.
+	 *                       should have in the near future, except that you need to
+	 *                       do something else right now.
 	 */
 	void pending(String futureBehavior);
 
@@ -101,21 +103,26 @@ public interface JavaSpec {
 	 * complete the verification or fix the bug that is causing the spec to fail.
 	 * Results in a disabled (skipped) JUnit test.
 	 *
-	 * @param intendedBehavior A description of some behavior the subject was
-	 * already supposed to have, except something went wrong and you have to do
-	 * something else right now.
+	 * @param intendedBehavior   A description of some behavior the subject was
+	 *                           already supposed to have, except something went
+	 *                           wrong and you have to do something else right now.
 	 * @param brokenVerification A lambda that contains the test in the typical
-	 * Arrange-Act-Assert pattern, except it's broken and you need to disable it
-	 * long enough to focus on fixing something else right now.
+	 *                           Arrange-Act-Assert pattern, except it's broken and
+	 *                           you need to disable it long enough to focus on
+	 *                           fixing something else right now.
 	 */
 	void skip(String intendedBehavior, Verification brokenVerification);
 
 	/**
-	 * A lambda with specs that are related to each other, or more containers.
-	 * Call {@link JavaSpec#it(String, Verification)} inside of this.
+	 * A lambda with specs that are related to each other, or more containers. Call
+	 * {@link JavaSpec#it(String, Verification)} inside of this.
 	 */
 	@FunctionalInterface
 	interface BehaviorDeclaration {
+		/**
+		 * A lambda with specs that are related to each other, or more containers. Call
+		 * {@link JavaSpec#it(String, Verification)} inside of this.
+		 */
 		void declare();
 	}
 }

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
@@ -23,7 +23,19 @@
  */
 package info.javaspec.api;
 
-/** A class with specs in it */
+/**
+ * Entrypoint into writing specs (tests) in JavaSpec, like a JUnit Test class.
+ */
 public interface SpecClass {
+	/**
+	 * Implement this method to declare specs in JavaSpec, using the given API.
+	 *
+	 * @param javaspec The API you need to declare specs.  Start with
+	 * {@link JavaSpec#describe(Class, info.javaspec.api.JavaSpec.BehaviorDeclaration)}
+	 * or
+	 * {@link JavaSpec#describe(String, info.javaspec.api.JavaSpec.BehaviorDeclaration)}
+	 * and then declare 1 or more specs with
+	 * {@link JavaSpec#it(String, Verification)}.
+	 */
 	void declareSpecs(JavaSpec javaspec);
 }

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
@@ -23,7 +23,7 @@
  */
 package info.javaspec.api;
 
-//A class with specs in it
+/** A class with specs in it */
 public interface SpecClass {
 	void declareSpecs(JavaSpec javaspec);
 }

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/SpecClass.java
@@ -30,12 +30,12 @@ public interface SpecClass {
 	/**
 	 * Implement this method to declare specs in JavaSpec, using the given API.
 	 *
-	 * @param javaspec The API you need to declare specs.  Start with
-	 * {@link JavaSpec#describe(Class, info.javaspec.api.JavaSpec.BehaviorDeclaration)}
-	 * or
-	 * {@link JavaSpec#describe(String, info.javaspec.api.JavaSpec.BehaviorDeclaration)}
-	 * and then declare 1 or more specs with
-	 * {@link JavaSpec#it(String, Verification)}.
+	 * @param javaspec The API you need to declare specs. Start with
+	 *                 {@link JavaSpec#describe(Class, info.javaspec.api.JavaSpec.BehaviorDeclaration)}
+	 *                 or
+	 *                 {@link JavaSpec#describe(String, info.javaspec.api.JavaSpec.BehaviorDeclaration)}
+	 *                 and then declare 1 or more specs with
+	 *                 {@link JavaSpec#it(String, Verification)}.
 	 */
 	void declareSpecs(JavaSpec javaspec);
 }

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/Verification.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/Verification.java
@@ -23,7 +23,7 @@
  */
 package info.javaspec.api;
 
-//A procedure that verifies the behavior under test
+/** A procedure that verifies the behavior under test */
 @FunctionalInterface
 public interface Verification {
 	void execute();

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/Verification.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/Verification.java
@@ -23,8 +23,16 @@
  */
 package info.javaspec.api;
 
-/** A procedure that verifies the behavior under test */
+/**
+ * A procedure that verifies the behavior under test.  This is where you write
+ * the code to Arrange, Act, and Assert.
+ */
 @FunctionalInterface
 public interface Verification {
+	/**
+	 * Lambda containing the contents of the specification.  Throw unchecked
+	 * throwables like AssertionError and the like to indicate test failures, like
+	 * you would do in JUnit.
+	 */
 	void execute();
 }

--- a/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/Verification.java
+++ b/nested-lambdas/javaspec-api/src/main/java/info/javaspec/api/Verification.java
@@ -24,13 +24,13 @@
 package info.javaspec.api;
 
 /**
- * A procedure that verifies the behavior under test.  This is where you write
+ * A procedure that verifies the behavior under test. This is where you write
  * the code to Arrange, Act, and Assert.
  */
 @FunctionalInterface
 public interface Verification {
 	/**
-	 * Lambda containing the contents of the specification.  Throw unchecked
+	 * Lambda containing the contents of the specification. Throw unchecked
 	 * throwables like AssertionError and the like to indicate test failures, like
 	 * you would do in JUnit.
 	 */

--- a/nested-lambdas/javaspec-client/build.gradle
+++ b/nested-lambdas/javaspec-client/build.gradle
@@ -17,12 +17,13 @@ dependencies {
 //  testRuntimeOnly project(':jupiter-test-execution-listener')
 }
 
-javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
-licenseConvention.licenseFile = rootProject.file('../LICENSE')
-
 java {
 	jar {
 		//Example sources only.  Not meant to be published as an artifact.
 		enabled = false
 	}
 }
+
+javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
+
+licenseConvention.licenseFile = rootProject.file('../LICENSE')

--- a/nested-lambdas/javaspec-engine-discovery-request-listener/build.gradle
+++ b/nested-lambdas/javaspec-engine-discovery-request-listener/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java-library'
+	id 'local.jar-convention'
 	id 'local.java-format-convention'
 	id 'local.license-convention'
 }
@@ -12,5 +13,8 @@ dependencies {
 	implementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
+jarConvention.licenseFile = rootProject.file('../LICENSE')
+
 javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
+
 licenseConvention.licenseFile = rootProject.file('../LICENSE')

--- a/nested-lambdas/javaspec-engine/build.gradle
+++ b/nested-lambdas/javaspec-engine/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java-library'
+	id 'local.jar-convention'
 	id 'local.java-format-convention'
 	id 'local.java-junit-convention'
 	id 'local.license-convention'
@@ -26,8 +27,12 @@ dependencies {
 //  testRuntimeOnly project(':javaspec-engine-discovery-request-listener')
 }
 
+jarConvention.licenseFile = rootProject.file('../LICENSE')
+
 javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
+
 licenseConvention.licenseFile = rootProject.file('../LICENSE')
+
 mavenPublishConvention {
 	publicationDescription = project.description
 	publicationFrom = components.java

--- a/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/EngineDiscoveryRequestListener.java
+++ b/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/EngineDiscoveryRequestListener.java
@@ -25,7 +25,23 @@ package info.javaspec.engine;
 
 import org.junit.platform.engine.EngineDiscoveryRequest;
 
-//Receives an EngineDiscoveryRequest, upon JavaSpecEngine#discover.
+/**
+ * A listener for what the JUnit Platform passes to {@link JavaSpecEngine} to
+ * configure the process of test discovery. Providing an implementation at
+ * runtime can help in debugging, by clarifying exactly what the platform is
+ * passing to the engine.
+ *
+ * <p>
+ * <strong>Note: This only works with JavaSpecEngine. It does not work with
+ * other JUnit TestEngines.</strong>
+ * </p>
+ */
 public interface EngineDiscoveryRequestListener {
+	/**
+	 * Receives an EngineDiscoveryRequest, upon
+	 * {@link JavaSpecEngine#discover(EngineDiscoveryRequest, UniqueId)}.
+	 *
+	 * @param request The discovery request received from the JUnit Platform
+	 */
 	void onDiscover(EngineDiscoveryRequest request);
 }

--- a/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
+++ b/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/JavaSpecEngine.java
@@ -28,7 +28,57 @@ import java.util.ServiceLoader;
 import org.junit.platform.engine.*;
 import org.junit.platform.engine.discovery.ClassSelector;
 
-// Orchestrates the process of discovering and running specs in a Jupiter runtime.
+/**
+ * Orchestrates the process of discovering and running specs on the JUnit
+ * Platform. Add the artifact containing this class to the runtime classpath, so
+ * that the JUnit Platform can find and execute specs using this engine.
+ *
+ * <h2>Use with JUnit Platform Console</h2>
+ *
+ * Users of the JUnit Platform Console can include the engine by adding
+ * classpaths for the JavaSpec API and this TestEngine, as in this script
+ * example:
+ *
+ * <pre>
+ * {@code
+ * junit_console_jar='junit-platform-console-standalone-1.8.1.jar'
+ * java -jar "$junit_console_jar" \
+ *   --classpath=info.javaspec.javaspec-api-0.0.1.jar \
+ *   --classpath=<compiled production code and its dependencies> \
+ *   --classpath=<compiled specs and their dependencies> \
+ *   --classpath=info.javaspec.javaspec-engine-0.0.1.jar \
+ *   --include-engine=javaspec-engine \
+ *   ...
+ * }
+ * </pre>
+ *
+ * <h2>Use with Gradle</h2>
+ *
+ * Users who are already using Gradle need to add some dependencies and tell
+ * Gradle to use the JUnit Platform for running tests:
+ *
+ * <pre>
+ * {@code
+ * //build.gradle
+ * plugins {
+ *   id 'java' //or one of the other Java plugins like 'java-library'
+ * }
+ *
+ * dependencies {
+ *   //Add these dependencies for JavaSpec
+ *   testImplementation 'info.javaspec:javaspec-api:<version>'
+ *   testRuntimeOnly 'info.javaspec:javaspec-engine:<version>'
+ *
+ *   //Add an assertion library (JUnit 5's assertions shown here)
+ *   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+ * }
+ *
+ * test {
+ *   useJUnitPlatform()
+ * }
+ * }
+ * </pre>
+ */
 public class JavaSpecEngine implements TestEngine {
 	private final EngineDiscoveryRequestListenerProvider loader;
 

--- a/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDeclaration.java
+++ b/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDeclaration.java
@@ -33,7 +33,7 @@ import java.util.Stack;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 
-// Runs JavaSpec declarations in a SpecClass, converting them to TestDescriptors Jupiter can use.
+//Runs JavaSpec declarations in a SpecClass, converting them to TestDescriptors Jupiter can use.
 final class SpecClassDeclaration implements JavaSpec {
 	private final Class<?> selectedClass;
 	private final Stack<ContextDescriptor> containersInScope;

--- a/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDeclaration.java
+++ b/nested-lambdas/javaspec-engine/src/main/java/info/javaspec/engine/SpecClassDeclaration.java
@@ -23,6 +23,7 @@
  */
 package info.javaspec.engine;
 
+import info.javaspec.api.BehaviorDeclaration;
 import info.javaspec.api.JavaSpec;
 import info.javaspec.api.SpecClass;
 import info.javaspec.api.Verification;

--- a/nested-lambdas/jupiter-test-execution-listener/build.gradle
+++ b/nested-lambdas/jupiter-test-execution-listener/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java-library'
+	id 'local.jar-convention'
 	id 'local.java-format-convention'
 	id 'local.license-convention'
 }
@@ -11,5 +12,8 @@ dependencies {
 	implementation 'org.junit.platform:junit-platform-launcher:1.8.1'
 }
 
+jarConvention.licenseFile = rootProject.file('../LICENSE')
+
 javaFormatConvention.eclipseConfigFile = rootProject.file('etc/eclipse-format.xml')
+
 licenseConvention.licenseFile = rootProject.file('../LICENSE')


### PR DESCRIPTION
Configure Gradle to build SNAPSHOT jars for an upcoming 2.x release.  This also includes:

* Add a `local.jar-convention` plugin to generate source and Javadoc JARs too
* Add Javadoc to public classes in `javaspec-api` and `javaspec-engine`, so that users get some useful information during development.
* Include `META-INF/LICENSE` as a standalone file in all published JARs
* Include a license reference in the generated POM files
* Organize developer documentation a little more
* Fix a bug in the `pre-commit` script that allowed formatting errors to pass
* 