### PR TITLE
Add workflow to deploy snapshot artifacts to Sonatype

### DIFF
--- a/.github/workflows/main_pull_request.yml
+++ b/.github/workflows/main_pull_request.yml
@@ -21,9 +21,6 @@ jobs:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
 
-      - name: Verify GPG configuration
-        run: gpg --list-keys
-
       - name: Make scripts executable
         working-directory: './nested-lambdas'
         run: chmod +x gradlew

--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -34,10 +34,11 @@ jobs:
         run: ./gradlew build
 
       - name: Publish Artifacts
-        #TODO KDK: Add secrets here for Sonatype
         working-directory: './nested-lambdas'
         run: |
           ./gradlew \
           -Psigning.key="${{ secrets.GPG_PRIVATE_KEY }}" \
           -Psigning.passphrase="${{ secrets.GPG_PASSPHRASE }}" \
+          -Psonatype.username=${{ secrets.SONATYPE_USERNAME }} \
+          -Psonatype.password=${{ secrets.SONATYPE_PASSWORD }} \
           publish

--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -33,15 +33,8 @@ jobs:
         working-directory: './nested-lambdas'
         run: ./gradlew build
 
-      # - name: Sign Artifacts
-      #   working-directory: './nested-lambdas'
-      #   run: |
-      #     ./gradlew \
-      #     -Psigning.key="${{ secrets.GPG_PRIVATE_KEY }}" \
-      #     -Psigning.passphrase="${{ secrets.GPG_PASSPHRASE }}" \
-      #     signMavenPublication
-
       - name: Publish Artifacts
+        #TODO KDK: Add secrets here for Sonatype
         working-directory: './nested-lambdas'
         run: |
           ./gradlew \

--- a/nested-lambdas/doc/developing-javaspec.md
+++ b/nested-lambdas/doc/developing-javaspec.md
@@ -185,27 +185,6 @@ See `buildSrc/local.jar-convention.gradle` for details.
 [gradle-bundling]: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Jar.html
 
 
-### Continuous Integration/Delivery (CI/CD) with Github Actions
-
-This project uses Github Actions for Continuous Integration (CI) and Continuous
-Delivery (CD).  See [Github Actions Syntax][github-actions-syntax] for details.
-
-This project has the following workflows, which are defined in
-`.github/workflows/`:
-
-* `main_pull_request.yml`: Runs when a Pull Request is created or updated.  it
-  builds the project, runs tests and other checks, and assembles artifacts.
-* `main_push.yml`: Runs when there is any kind of merge (or direct push) back
-  into `main`.  It signs and deploys SNAPSHOT artifacts to Sonatype OSSRH so
-  that developers can test the entire process of fetching and using
-  dependencies, with the latest version of the project.
-* _To be determined_: Deploy release artifacts to a Sonatype OSSRH staging
-  repository, for eventual promotion to the Maven Central Repository (i.e.
-  public availability).
-
-[github-actions-syntax]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
-
-
 ### Format Java sources with Spotless
 
 Add the `local.java-format-convention` plugin to a project, to add Gradle tasks
@@ -328,6 +307,27 @@ dependencies {
 
 If you maintain this repository or manage releases, you will need a way to sign
 and publish artifacts with Gradle.
+
+
+### Continuous Integration/Delivery (CI/CD) with Github Actions
+
+This project uses Github Actions for Continuous Integration (CI) and Continuous
+Delivery (CD).  See [Github Actions Syntax][github-actions-syntax] for details.
+
+This project has the following workflows, which are defined in
+`.github/workflows/`:
+
+* `main_pull_request.yml`: Runs when a Pull Request is created or updated.  It
+  builds the project, runs tests and other checks, and assembles artifacts.
+* `main_push.yml`: Runs when there is any kind of merge (or direct push) back
+  into `main`.  It signs and deploys SNAPSHOT artifacts to Sonatype OSSRH so
+  that developers can test the entire process of fetching and using
+  dependencies, with the latest version of the project.
+* _To be determined_: Deploy release artifacts to a Sonatype OSSRH staging
+  repository, for eventual promotion to the Maven Central Repository (i.e.
+  public availability).
+
+[github-actions-syntax]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 
 
 ### Publish artifacts to Maven Local


### PR DESCRIPTION
Makes the snapshot deployment work, after adding the placeholder workflow.