### PR TITLE
Prep for release 2.0.0

### DIFF
--- a/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
+++ b/nested-lambdas/buildSrc/src/main/groovy/local.jar-convention.gradle
@@ -10,7 +10,9 @@ afterEvaluate {
 	java {
 		tasks.named('javadoc', Javadoc) {
 			options.addStringOption('link', 'https://docs.oracle.com/javase/8/docs/api')
-			options.addStringOption('link', 'https://junit.org/junit5/docs/current/api/')
+			//Avoid warnings about the unnamed module refering to other, named modules
+			// https://stackoverflow.com/questions/58836862/jdk-11-and-javadoc
+			// options.addStringOption('link', 'https://junit.org/junit5/docs/current/api/')
 			options.addStringOption('source', '1.8')
 		}
 

--- a/nested-lambdas/javaspec-api/build.gradle
+++ b/nested-lambdas/javaspec-api/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 description 'Everything needed to declare specs'
-version '2.0.0-SNAPSHOT'
+version '2.0.0'
 
 dependencies { }
 

--- a/nested-lambdas/javaspec-client/build.gradle
+++ b/nested-lambdas/javaspec-client/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 description 'Example project that uses JavaSpec for its tests'
-version '2.0.0-SNAPSHOT'
+version '2.0.0'
 
 dependencies {
 	testImplementation project(':javaspec-api')

--- a/nested-lambdas/javaspec-engine-discovery-request-listener/build.gradle
+++ b/nested-lambdas/javaspec-engine-discovery-request-listener/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 description 'Service Provider: an EngineDiscoveryRequestListener that reports DiscoveryRequests to the console'
-version '2.0.0-SNAPSHOT'
+version '2.0.0'
 
 dependencies {
 	implementation project(':javaspec-engine')

--- a/nested-lambdas/javaspec-engine/build.gradle
+++ b/nested-lambdas/javaspec-engine/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 description 'Service Provider: A TestEngine that runs specs on JUnit Jupiter'
-version '2.0.0-SNAPSHOT' //Has to go above other tasks that refer to it
+version '2.0.0' //Has to go above other tasks that refer to it
 
 sourceSets {
 	//Add a sourceset for the sake of declaring a dependency on JUnit Console

--- a/nested-lambdas/jupiter-test-execution-listener/build.gradle
+++ b/nested-lambdas/jupiter-test-execution-listener/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 description 'Service Provider: a TestExecutionListener that reports test execution events to the console'
-version '2.0.0-SNAPSHOT'
+version '2.0.0'
 
 dependencies {
 	implementation 'org.junit.platform:junit-platform-launcher:1.8.1'


### PR DESCRIPTION
Bump the version to `2.0.0`.

Addresses some javadoc warnings along the way.