### PR TITLE
Add Google Analytics 4 to main web page

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,8 +9,8 @@ description: >-
 github_username: kkrull
 google_analytics: G-RHQPKBC4T7
 title: JavaSpec 2.0
-url: "https://javaspec.info" #protocol + base hostname, e.g. http://example.com
 twitter_username: KrullKyle
+url: "https://javaspec.info" #protocol + base hostname, e.g. http://example.com
 
 remote_theme: pages-themes/leap-day@v0.2.0
 plugins:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,7 +7,7 @@ description: >-
   JavaSpec 2.x is a Java library that lets you use lambdas to write
   specifications that run on the JUnit 5 platform.
 github_username: kkrull
-google_analytics: UA-54933252-1
+google_analytics: G-RHQPKBC4T7
 title: JavaSpec 2.0
 url: "https://javaspec.info" #protocol + base hostname, e.g. http://example.com
 twitter_username: KrullKyle

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,6 +7,7 @@ description: >-
   JavaSpec 2.x is a Java library that lets you use lambdas to write
   specifications that run on the JUnit 5 platform.
 github_username: kkrull
+google_analytics: UA-54933252-1
 title: JavaSpec 2.0
 url: "https://javaspec.info" #protocol + base hostname, e.g. http://example.com
 twitter_username: KrullKyle

--- a/docs/_includes/google-analytics.html
+++ b/docs/_includes/google-analytics.html
@@ -1,9 +1,9 @@
 <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-54933252-1"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-RHQPKBC4T7"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'UA-54933252-1');
+  gtag('config', 'G-RHQPKBC4T7');
 </script>

--- a/docs/_includes/google-analytics.html
+++ b/docs/_includes/google-analytics.html
@@ -1,0 +1,9 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-54933252-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-54933252-1');
+</script>


### PR DESCRIPTION
Add Analytics 4 following these instructions: https://support.google.com/analytics/answer/9744165?hl=en&utm_id=ad#zippy=%2Cin-this-article%2Cinstall-a-google-tag